### PR TITLE
wildcard mime-type for file

### DIFF
--- a/dist/swagger/account-info-swagger.json
+++ b/dist/swagger/account-info-swagger.json
@@ -1088,6 +1088,7 @@
             "$ref": "#/parameters/x-customer-user-agent"
           }
         ],
+        "produces": ["*/*"],
         "responses": {
           "200": {
             "$ref": "#/responses/200AccountsAccountIdStatementsStatementIdFileRead"

--- a/dist/swagger/payment-initiation-swagger.json
+++ b/dist/swagger/payment-initiation-swagger.json
@@ -1281,6 +1281,7 @@
             "$ref": "#/parameters/x-customer-user-agent"
           }
         ],
+        "produces": ["*/*"],
         "responses": {
           "200": {
             "$ref": "#/responses/200FilePaymentConsentsConsentIdFileCreated"


### PR DESCRIPTION
The 3.0 & flattened files are not generated as it seems that the scripts end up rewriting most part of the files which would need verification.