### PR TITLE
Hotfix CDRW-3503 Incorrect Transaction Code and Sub Field Size

### DIFF
--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -10244,19 +10244,12 @@
         "type": "object",
         "properties": {
           "Code": {
-            "maxLength": 4,
-            "minLength": 1,
-            "type": "string",
-            "description": "Specifies the family within a domain."
+            "$ref": "#/components/schemas/ExternalBankTransactionFamily1Code"
           },
           "SubCode": {
-            "maxLength": 4,
-            "minLength": 1,
-            "type": "string",
-            "description": "Specifies the sub-product family within a specific family."
+            "$ref": "#/components/schemas/ExternalBankTransactionSubFamily1Code"
           }
-        },
-        "description": "Set of elements used to fully identify the type of underlying transaction resulting in an entry."
+        }
       },
       "OBBeneficiary5": {
         "type": "object",
@@ -17863,6 +17856,14 @@
         "type": "string",
         "description": "Date and time at which assets become available to the account owner in case of a credit entry, or cease to be available to the account owner in case of a debit transaction entry.\nUsage: If transaction entry status is pending and value date is present, then the value date refers to an expected/requested value date.\nFor transaction entries subject to availability/float and for which availability information is provided, the value date must not be used. In this case the availability component identifies the number of availability days.All dates in the JSON payloads are represented in ISO 8601 date-time format. \nAll date-time fields in responses must include the timezone. An example is below:\n2017-04-05T10:43:07+00:00",
         "format": "date-time"
+      },
+      "ExternalBankTransactionFamily1Code": {
+        "type": "string",
+        "description": "Specifies the family within a domain."
+      },
+      "ExternalBankTransactionSubFamily1Code": {
+        "type": "string",
+        "description": "Specifies the sub-product family within a specific family."
       }
     },
     "responses": {

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -7473,17 +7473,9 @@ components:
       type: object
       properties:
         Code:
-          maxLength: 4
-          minLength: 1
-          type: string
-          description: Specifies the family within a domain.
+          $ref: '#/components/schemas/ExternalBankTransactionFamily1Code'
         SubCode:
-          maxLength: 4
-          minLength: 1
-          type: string
-          description: Specifies the sub-product family within a specific family.
-      description: Set of elements used to fully identify the type of underlying transaction
-        resulting in an entry.
+          $ref: '#/components/schemas/ExternalBankTransactionSubFamily1Code'
     OBBeneficiary5:
       type: object
       properties:
@@ -13932,6 +13924,12 @@ components:
         \ in ISO 8601 date-time format. \nAll date-time fields in responses must include\
         \ the timezone. An example is below:\n2017-04-05T10:43:07+00:00"
       format: date-time
+    ExternalBankTransactionFamily1Code:
+      type: string
+      description: Specifies the family within a domain.
+    ExternalBankTransactionSubFamily1Code:
+        type: string
+        description: Specifies the sub-product family within a specific family.
   responses:
     200AccountAccessConsentsConsentIdRead:
       description: Account Access Consents Read

--- a/dist/swagger/account-info-swagger.json
+++ b/dist/swagger/account-info-swagger.json
@@ -5594,15 +5594,11 @@
       "properties": {
         "Code": {
           "description": "Specifies the family within a domain.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 4
+          "type": "string"
         },
         "SubCode": {
           "description": "Specifies the sub-product family within a specific family.",
-          "type": "string",
-          "minLength": 1,
-          "maxLength": 4
+          "type": "string"
         }
       }
     },

--- a/dist/swagger/account-info-swagger.yaml
+++ b/dist/swagger/account-info-swagger.yaml
@@ -4064,13 +4064,9 @@ definitions:
       Code:
         description: Specifies the family within a domain.
         type: string
-        minLength: 1
-        maxLength: 4
       SubCode:
         description: Specifies the sub-product family within a specific family.
         type: string
-        minLength: 1
-        maxLength: 4
   OBBeneficiary5:
     type: object
     properties:


### PR DESCRIPTION
**Problem:**

Bank transaction code and sub code max lengths doesn't allow long form description. [Spec Ref](https://openbankinguk.github.io/read-write-api-site3/v3.1.4/resources-and-data-models/aisp/Transactions.html#notes)

"_The BankTransactionCode Code and SubCode will be populated with the long form description of the ISO 20022 code, with delimiters removed. E.g., the Family Code "CNTR" has a description of "Counter Transactions" which is populated as "CounterTransactions_"

**Change:** Removed min and max lengths in OBBankTransactionCodeStructure1 for Code (ExternalBankTransactionFamily1Code) and SubCode (ExternalBankTransactionSubFamily1Code) in both OpenAPI 3 and Swagger definitions for 3 v3.1.6 transactions.
**Reason:** Sync spec, known issue.
**Files impacted:** account-info-openapi.json, account-info-openapi.yaml, account-info-api.json, account-info-api.yaml

**Change:** Added 2 new schema components ExternalBankTransactionFamily1Code and  ExternalBankTransactionSubFamily1Code
**Reason:** Align components Code and SubCode to match published specifications class names ExternalBankTransactionFamily1Code and ExternalBankTransactionSubFamily1Code respectively. Change was only made to OpenAPI 3 file formats to allow changes in 3.1.7 going forward.     
**Files impacted:** account-info-openapi.json, account-info-openapi.yaml
