### PR TITLE
fix RepresentativeAPR regex in 3.1.6

### DIFF
--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -8464,7 +8464,7 @@
                           },
                           "RepresentativeAPR": {
                             "title": "RepresentativeAPR",
-                            "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$",
+                            "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$",
                             "type": "string",
                             "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account."
                           },
@@ -11460,7 +11460,7 @@
                           },
                           "RepresentativeAPR": {
                             "title": "RepresentativeAPR",
-                            "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$",
+                            "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$",
                             "type": "string",
                             "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account."
                           },

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -5809,7 +5809,7 @@ components:
                             used interchangeably), being the actual annual interest rate of an Overdraft.
                         RepresentativeAPR:
                           title: RepresentativeAPR
-                          pattern: ^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$
+                          pattern: ^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$
                           type: string
                           description: An annual percentage rate (APR) is the annual
                             rate charged for borrowing or earned through an investment.
@@ -8544,7 +8544,7 @@ components:
                             used interchangeably), being the actual annual interest rate of an Overdraft.
                         RepresentativeAPR:
                           title: RepresentativeAPR
-                          pattern: ^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$
+                          pattern: ^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$
                           type: string
                           description: An annual percentage rate (APR) is the annual
                             rate charged for borrowing or earned through an investment.

--- a/dist/swagger-flattened/account-info-swagger-flattened.json
+++ b/dist/swagger-flattened/account-info-swagger-flattened.json
@@ -10967,7 +10967,7 @@
                                                 "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.",
                                                 "title": "RepresentativeAPR",
                                                 "type": "string",
-                                                "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$"
+                                                "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                                               },
                                               "AgreementLengthMin": {
                                                 "description": "Specifies the minimum length of a band for a fixed overdraft agreement",
@@ -13209,7 +13209,7 @@
                                                 "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.",
                                                 "title": "RepresentativeAPR",
                                                 "type": "string",
-                                                "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$"
+                                                "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                                               },
                                               "Notes": {
                                                 "description": "Optional additional notes to supplement the Tier/band details",
@@ -28604,7 +28604,7 @@
                                                 "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.",
                                                 "title": "RepresentativeAPR",
                                                 "type": "string",
-                                                "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$"
+                                                "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                                               },
                                               "AgreementLengthMin": {
                                                 "description": "Specifies the minimum length of a band for a fixed overdraft agreement",
@@ -30846,7 +30846,7 @@
                                                 "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.",
                                                 "title": "RepresentativeAPR",
                                                 "type": "string",
-                                                "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$"
+                                                "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                                               },
                                               "Notes": {
                                                 "description": "Optional additional notes to supplement the Tier/band details",

--- a/dist/swagger/account-info-swagger.json
+++ b/dist/swagger/account-info-swagger.json
@@ -3788,7 +3788,7 @@
                           "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.",
                           "title": "RepresentativeAPR",
                           "type": "string",
-                          "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$"
+                          "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                         },
                         "AgreementLengthMin": {
                           "description": "Specifies the minimum length of a band for a fixed overdraft agreement",
@@ -6815,7 +6815,7 @@
                           "description": "An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.",
                           "title": "RepresentativeAPR",
                           "type": "string",
-                          "pattern": "^(-?\\\\d{1,3}){1}(\\\\.\\\\d{1,4}){0,1}$"
+                          "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                         },
                         "Notes": {
                           "description": "Optional additional notes to supplement the Tier/band details",

--- a/dist/swagger/account-info-swagger.yaml
+++ b/dist/swagger/account-info-swagger.yaml
@@ -2579,7 +2579,7 @@ definitions:
                         description: An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.
                         title: RepresentativeAPR
                         type: string
-                        pattern: '^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$'
+                        pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
                       AgreementLengthMin:
                         description: Specifies the minimum length of a band for a fixed overdraft agreement
                         title: AgreementLengthMin
@@ -5072,7 +5072,7 @@ definitions:
                         description: An annual percentage rate (APR) is the annual rate charged for borrowing or earned through an investment. APR is expressed as a percentage that represents the actual yearly cost of funds over the term of a loan. This includes any fees or additional costs associated with the transaction but does not take compounding into account.
                         title: RepresentativeAPR
                         type: string
-                        pattern: '^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$'
+                        pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
                       Notes:
                         description: Optional additional notes to supplement the Tier/band details
                         title: Notes


### PR DESCRIPTION
Correcting duplicated escape in the regex used in RepresentativeAPR.