### PR TITLE
Correct VRP Spec parameter names

### DIFF
--- a/dist/openapi/vrp-openapi.json
+++ b/dist/openapi/vrp-openapi.json
@@ -426,7 +426,7 @@
         ]
       }
     },
-    "/domestic-vrps/{ConsentId}": {
+    "/domestic-vrps/{DomesticVRPId}": {
       "get": {
         "operationId": "domesticVrpGet",
         "tags": [
@@ -436,7 +436,7 @@
         "description": "Retrieve a domestic VRP",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ConsentId"
+            "$ref": "#/components/parameters/DomesticVRPId"
           },
           {
             "$ref": "#/components/parameters/x-fapi-auth-date"
@@ -492,7 +492,7 @@
         ]
       }
     },
-    "/domestic-vrps/{ConsentId}/payment-details": {
+    "/domestic-vrps/{DomesticVRPId}/payment-details": {
       "get": {
         "operationId": "domesticVrpPaymentDetailsGet",
         "tags": [
@@ -502,7 +502,7 @@
         "description": "Retrieve a domestic VRP",
         "parameters": [
           {
-            "$ref": "#/components/parameters/ConsentId"
+            "$ref": "#/components/parameters/DomesticVRPId"
           },
           {
             "$ref": "#/components/parameters/x-fapi-auth-date"
@@ -897,6 +897,15 @@
         "name": "ConsentId",
         "in": "path",
         "description": "ConsentId",
+        "required": true,
+        "schema": {
+          "type": "string"
+        }
+      },
+      "DomesticVRPId": {
+        "name": "DomesticVRPId",
+        "in": "path",
+        "description": "DomesticVRPId",
         "required": true,
         "schema": {
           "type": "string"

--- a/dist/openapi/vrp-openapi.yaml
+++ b/dist/openapi/vrp-openapi.yaml
@@ -263,7 +263,7 @@ paths:
         - TPPOAuth2Security:
             - "payments"
 
-  /domestic-vrps/{ConsentId}:
+  /domestic-vrps/{DomesticVRPId}:
     get:
       operationId: domesticVrpGet
       tags:
@@ -271,7 +271,7 @@ paths:
       summary: Retrieve a domestic VRP
       description: Retrieve a domestic VRP
       parameters:
-        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/DomesticVRPId"
         - $ref: "#/components/parameters/x-fapi-auth-date"
         - $ref: "#/components/parameters/x-fapi-customer-ip-address"
         - $ref: "#/components/parameters/x-fapi-interaction-id"
@@ -302,7 +302,7 @@ paths:
         - TPPOAuth2Security:
             - "payments"
 
-  /domestic-vrps/{ConsentId}/payment-details:
+  /domestic-vrps/{DomesticVRPId}/payment-details:
     get:
       operationId: domesticVrpPaymentDetailsGet
       tags:
@@ -310,7 +310,7 @@ paths:
       summary: Retrieve a domestic VRP
       description: Retrieve a domestic VRP
       parameters:
-        - $ref: "#/components/parameters/ConsentId"
+        - $ref: "#/components/parameters/DomesticVRPId"
         - $ref: "#/components/parameters/x-fapi-auth-date"
         - $ref: "#/components/parameters/x-fapi-customer-ip-address"
         - $ref: "#/components/parameters/x-fapi-interaction-id"
@@ -571,7 +571,14 @@ components:
       description: "ConsentId"
       required: true
       schema:
-        type: "string"  
+        type: "string"
+    DomesticVRPId:
+      name: "DomesticVRPId"
+      in: "path"
+      description: "DomesticVRPId"
+      required: true
+      schema:
+        type: "string"
     Authorization:
       in: "header"
       name: "Authorization"


### PR DESCRIPTION
- Rename ConsentId to DomesticVRPId where appropriate