### PR TITLE
Remove PaymentTransationId requirement in top level Data

### DIFF
--- a/dist/openapi/vrp-openapi.json
+++ b/dist/openapi/vrp-openapi.json
@@ -1551,9 +1551,6 @@
         "properties": {
           "Data": {
             "type": "object",
-            "required": [
-              "PaymentTransactionId"
-            ],
             "properties": {
               "PaymentStatus": {
                 "type": "array",

--- a/dist/openapi/vrp-openapi.yaml
+++ b/dist/openapi/vrp-openapi.yaml
@@ -1123,8 +1123,6 @@ components:
       properties:
         Data:
           type: object
-          required:
-            - PaymentTransactionId
           properties:
             PaymentStatus:
               type: array


### PR DESCRIPTION
PaymentTransationId was incorrectly referenced as required field in the Data object
in from top-level Data of OBDomesticVRPDetails