### PR TITLE
Remove duplicate pattern block from confirmation-funds-openapi.yaml

### DIFF
--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -207,10 +207,6 @@ components:
           ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
           (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}
           \d{2}:\d{2}:\d{2} (GMT|UTC)$
-        pattern: >-
-          ^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2}
-          (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4}
-          \d{2}:\d{2}:\d{2} (GMT|UTC)$
     x-fapi-interaction-id:
       in: header
       name: x-fapi-interaction-id


### PR DESCRIPTION
Fixing the YAML syntax for confirmation-funds-openapi.yaml by removing the duplicate pattern block within the x-fapi-auth-date definition.

This fix is required in order to be able to generate code from the schema using https://github.com/OpenAPITools/openapi-generator