### PR TITLE
Fix ob code mnemonic regex typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ Please refer to the [Known Issues](https://openbanking.atlassian.net/wiki/spaces
     Some payment status codes were present on the Spec pages but not in the swagger.
 3. Fixed VRP PATCH operation description
     The description was appearing in the `format` field and has been moved to the correct `description` field.
-4. PR #189 - Corrected a typo in the OB code mnemonic regular expression, improving validation accuracy for mnemonics. Related to v40_KI30.
+4. PR [#189](https://github.com/OpenBankingUK/read-write-api-specs/pull/189/) - Corrected a typo in the OB code mnemonic regular expression. Related to v40_KI30.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,3 +10,4 @@ Please refer to the [Known Issues](https://openbanking.atlassian.net/wiki/spaces
     Some payment status codes were present on the Spec pages but not in the swagger.
 3. Fixed VRP PATCH operation description
     The description was appearing in the `format` field and has been moved to the correct `description` field.
+4. PR #189 - Corrected a typo in the OB code mnemonic regular expression, improving validation accuracy for mnemonics. Related to v40_KI30.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,4 +10,4 @@ Please refer to the [Known Issues](https://openbanking.atlassian.net/wiki/spaces
     Some payment status codes were present on the Spec pages but not in the swagger.
 3. Fixed VRP PATCH operation description
     The description was appearing in the `format` field and has been moved to the correct `description` field.
-4. PR [#189](https://github.com/OpenBankingUK/read-write-api-specs/pull/189/) - Corrected a typo in the OB code mnemonic regular expression. Related to v40_KI30.
+4. PR [#189](https://github.com/OpenBankingUK/read-write-api-specs/pull/189/) - Corrected a regex typo in AIS `OB_CodeMnemonic`. Related to v40_KI30.

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -14262,7 +14262,7 @@
       "OB_CodeMnemonic": {
         "description": "The four letter Mnemonic used within an XML file to identify a code",
         "type": "string",
-        "pattern": "^\\\\w{0,4}$"
+        "pattern": "^\\w{0,4}$"
       },
       "OB_FeeCategory1Code": {
         "description": "Categorisation of fees and charges into standard categories.",

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -12436,7 +12436,7 @@ components:
     OB_CodeMnemonic:
       description: The four letter Mnemonic used within an XML file to identify a code
       type: string
-      pattern: ^\\w{0,4}$
+      pattern: ^\w{0,4}$
     OB_FeeCategory1Code:
       description: Categorisation of fees and charges into standard categories.
       type: string


### PR DESCRIPTION
The `OB_CodeMnemonic` regex pattern had legacy string literals (`\\`) that were not removed from the spec.

Before: `^\\w{0,4}$`
After: `^\w{0,4}$`

I have removed the extra `\` from the `account-info-openapi.yaml` file. Then I regenerated the `.json` file from the `yaml` file to include the changes.