### PR TITLE
CDRW-4743 Fix invalid `$ref` and `description` siblings.

### DIFF
--- a/dist/openapi/vrp-openapi.json
+++ b/dist/openapi/vrp-openapi.json
@@ -2351,8 +2351,14 @@
             "minLength": 1
           },
           "RelatedDate": {
-            "description": "Date associated with the referred document line.",
-            "$ref": "#/components/schemas/ISODateTime"
+            "allOf": [
+              {
+                "description": "Date associated with the referred document line."
+              },
+              {
+                "$ref": "#/components/schemas/ISODateTime"
+              }
+            ]
           },
           "LineDetails": {
             "description": "Set of elements used to provide the content of the referred document line.",
@@ -3057,8 +3063,14 @@
             "maxLength": 140
           },
           "CountryCode": {
-            "description": "Country of the entity that requires the regulatory reporting information.",
-            "$ref": "#/components/schemas/CountryCode"
+            "allOf": [
+              {
+                "description": "Country of the entity that requires the regulatory reporting information."
+              },
+              {
+                "$ref": "#/components/schemas/CountryCode"
+              }
+            ]
           }
         }
       },
@@ -3122,16 +3134,34 @@
             "maxLength": 35
           },
           "Date": {
-            "description": "Date related to the specified type of regulatory reporting details.",
-            "$ref": "#/components/schemas/ISODateTime"
+            "allOf": [
+              {
+                "description": "Date related to the specified type of regulatory reporting details."
+              },
+              {
+                "$ref": "#/components/schemas/ISODateTime"
+              }
+            ]
           },
           "Country": {
-            "description": "Country related to the specified type of regulatory reporting details.",
-            "$ref": "#/components/schemas/CountryCode"
+            "allOf": [
+              {
+                "description": "Country related to the specified type of regulatory reporting details."
+              },
+              {
+                "$ref": "#/components/schemas/CountryCode"
+              }
+            ]
           },
           "Amount": {
-            "description": "Amount of money to be reported for regulatory and statutory requirements.",
-            "$ref": "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+            "allOf": [
+              {
+                "description": "Amount of money to be reported for regulatory and statutory requirements."
+              },
+              {
+                "$ref": "#/components/schemas/OBActiveOrHistoricCurrencyAndAmount"
+              }
+            ]
           },
           "Information": {
             "description": "Additional details that cater for specific domestic regulatory requirements. ",

--- a/dist/openapi/vrp-openapi.yaml
+++ b/dist/openapi/vrp-openapi.yaml
@@ -1784,8 +1784,9 @@ components:
           maxLength: 35
           minLength: 1
         RelatedDate:
-          description: Date associated with the referred document line.
-          $ref: '#/components/schemas/ISODateTime'
+          allOf:
+            - description: Date associated with the referred document line.
+            - $ref: '#/components/schemas/ISODateTime'
         LineDetails:
           description: Set of elements used to provide the content of the referred document line.
           type: array
@@ -2443,8 +2444,9 @@ components:
           minLength: 1
           maxLength: 140
         CountryCode:
-          description: Country of the entity that requires the regulatory reporting information.
-          $ref: '#/components/schemas/CountryCode'
+          allOf:
+            - description: Country of the entity that requires the regulatory reporting information.
+            - $ref: '#/components/schemas/CountryCode'
     OBRegulatoryReporting1:
       type: object
       description: Information needed due to regulatory and statutory requirements
@@ -2503,14 +2505,17 @@ components:
           minLength: 1
           maxLength: 35
         Date:
-          description: Date related to the specified type of regulatory reporting details.
-          $ref: '#/components/schemas/ISODateTime'
+          allOf:
+            - description: Date related to the specified type of regulatory reporting details.
+            - $ref: '#/components/schemas/ISODateTime'
         Country:
-          description: Country related to the specified type of regulatory reporting details.
-          $ref: '#/components/schemas/CountryCode'
+          allOf:
+            - description: Country related to the specified type of regulatory reporting details.
+            - $ref: '#/components/schemas/CountryCode'
         Amount:
-          description: Amount of money to be reported for regulatory and statutory requirements.
-          $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
+          allOf:
+            - description: Amount of money to be reported for regulatory and statutory requirements.
+            - $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
         Information:
           description: >-
             Additional details that cater for specific domestic regulatory


### PR DESCRIPTION
In OAS v3.0.0 `$ref` cannot have direct siblings. So we have used `allOf:`'s to ground `$ref` and `description` which is valid.

Jira Ticket: https://openbanking.atlassian.net/browse/CDRW-4743