### PR TITLE
CDRW-4870 - update VRP OBCashAccountDebtorWithName

### DIFF
--- a/dist/openapi/vrp-openapi.json
+++ b/dist/openapi/vrp-openapi.json
@@ -1822,8 +1822,7 @@
         "type": "object",
         "required": [
           "SchemeName",
-          "Identification",
-          "Name"
+          "Identification"
         ],
         "properties": {
           "SchemeName": {
@@ -1838,7 +1837,7 @@
           "Name": {
             "type": "string",
             "minLength": 1,
-            "maxLength": 70,
+            "maxLength": 350,
             "description": "^ Name of the account, as assigned by the account servicing institution.  Usage The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account."
           },
           "SecondaryIdentification": {

--- a/dist/openapi/vrp-openapi.yaml
+++ b/dist/openapi/vrp-openapi.yaml
@@ -1289,7 +1289,6 @@ components:
       required:
         - SchemeName
         - Identification
-        - Name
       properties:
         SchemeName:
           $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
@@ -1303,7 +1302,7 @@ components:
         Name:
           type: string
           minLength: 1
-          maxLength: 70
+          maxLength: 350
           description: >-
             ^ Name of the account, as assigned by the account servicing
             institution.  Usage The account name is the name or names of the


### PR DESCRIPTION
VRP `OBCashAccountDebtorWithName` max length is increased from 70 to 350 characters and is no longer `mandatory`.