### PR TITLE
Add codes to OBFrequency6Code and OBFrequency2 Code

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v4.0.1 Release Candidate 2 - 
+## v4.0.1 Release Candidate 2 - Date TBC
 
 - Added `LWMH`, `LXMH`, & `TWYR` to `OBFrequency6Code` in AIS and PIS
 - Added `SLCT` to `OBFrequency2` in AIS

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Added `LWMH`, `LXMH`, & `TWYR` to `OBFrequency6Code` in AIS and PIS
+- Added `SLCT` to `OBFrequency2` in AIS
+
 ## v4.0.1 Release Candidate 1 - 2026-01-05
 
 ### Added

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v4.0.1 Release Candidate 2 - 
 
 - Added `LWMH`, `LXMH`, & `TWYR` to `OBFrequency6Code` in AIS and PIS
 - Added `SLCT` to `OBFrequency2` in AIS

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -7937,7 +7937,8 @@
           "TEND",
           "MOVE",
           "WEEK",
-          "NONE"
+          "NONE",
+          "SLCT"
         ]
       },
       "OBFrequencyPeriodType": {

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -3638,7 +3638,10 @@
           "FOMH",
           "FIMH",
           "ALMH",
-          "NONE"
+          "NONE",
+          "LWMH",
+          "LXMH",
+          "TWYR"
         ]
       },
       "OBProxy1": {

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -6555,6 +6555,7 @@ components:
         - MOVE
         - WEEK
         - NONE
+        - SLCT
     OBFrequencyPeriodType:
       description: |-
         Individual Definitions:

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -2252,6 +2252,9 @@ components:
         - FIMH
         - ALMH
         - NONE
+        - LWMH
+        - LXMH
+        - TWYR
     OBProxy1:
       description: >-
         Specifies an alternate assumed name for the identification of the

--- a/dist/openapi/payment-initiation-openapi.json
+++ b/dist/openapi/payment-initiation-openapi.json
@@ -6432,7 +6432,7 @@
         "example": "U001"
       },
       "OBFrequency6Code": {
-        "description": "`OBFrequency6Code` on External Codset Repo",
+        "description": "For a full list of values see `OBFrequency6Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "enum": [
           "ADHO",
@@ -6450,7 +6450,10 @@
           "FOMH",
           "FIMH",
           "ALMH",
-          "NONE"
+          "NONE",
+          "LWMH",
+          "LXMH",
+          "TWYR"
         ]
       },
       "OBMandateRelatedInformation1": {

--- a/dist/openapi/payment-initiation-openapi.yaml
+++ b/dist/openapi/payment-initiation-openapi.yaml
@@ -4406,7 +4406,7 @@ components:
       maxLength: 4
       example: U001
     OBFrequency6Code:
-      description: '`OBFrequency6Code` on External Codset Repo'
+      description: 'For a full list of values see `OBFrequency6Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)'
       type: string
       enum:
         - ADHO
@@ -4425,6 +4425,9 @@ components:
         - FIMH
         - ALMH
         - NONE
+        - LWMH
+        - LXMH
+        - TWYR
     OBMandateRelatedInformation1:
       type: object
       required:


### PR DESCRIPTION
- Added `LWMH`, `LXMH`, & `TWYR` to `OBFrequency6Code` in AIS and PIS
- Added `SLCT` to `OBFrequency2` in AIS

Related to:
- https://openbanking.atlassian.net/browse/CDRW-4867
- https://openbanking.atlassian.net/browse/CDRW-4863