### PR TITLE
RateType descriptions updated

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -10,8 +10,8 @@
 ### Changed
 
 - Updated example value in Error responses from `AC17` to `U001` in AIS and Events
-- Description for `OBReadStatement2/Data/Statement/StatementFee/RateType` changed to "This code indicates the specific type of fee rate (e.g., AER, EAR)"
-- Description for `OBReadStatement2/Data/Statement/StatementInterest/RateType` changed to "This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross)"
+- [CDRW-4948] Description for `OBReadStatement2/Data/Statement/StatementFee/RateType` changed to "This code indicates the specific type of fee rate (e.g., AER, EAR)"
+- [CDRW-4948] Description for `OBReadStatement2/Data/Statement/StatementInterest/RateType` changed to "This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross)"
 
 ## v4.0.1 Release Candidate 1 - 2026-01-05
 

--- a/changelog.md
+++ b/changelog.md
@@ -10,6 +10,8 @@
 ### Changed
 
 - Updated example value in Error responses from `AC17` to `U001` in AIS and Events
+- Description for `OBReadStatement2/Data/Statement/StatementFee/RateType` changed to "This code indicates the specific type of fee rate (e.g., AER, EAR)"
+- Description for `OBReadStatement2/Data/Statement/StatementInterest/RateType` changed to "This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross)"
 
 ## v4.0.1 Release Candidate 1 - 2026-01-05
 

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -7808,7 +7808,7 @@
         ]
       },
       "OBInternalStatementFeeRateType1Code": {
-        "description": "Description that may be available for the statement fee rate type. For a full list of values see `OBInternalStatementFeeRateType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "This code indicates the specific type of fee rate (e.g., AER, EAR). For a full list of values see `OBInternalStatementFeeRateType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "example": "UK.OBIE.AER",
         "x-namespaced-enum": [
@@ -7855,7 +7855,7 @@
         ]
       },
       "OBInternalStatementInterestRateType1Code": {
-        "description": "Description that may be available for the statement Interest rate type.",
+        "description": "This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross).",
         "type": "string",
         "example": "UK.OBIE.FixedRate",
         "x-namespaced-enum": [

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -6440,7 +6440,7 @@ components:
         - UK.OBIE.StatementMonthly
         - UK.OBIE.Weekly
     OBInternalStatementFeeRateType1Code:
-      description: Description that may be available for the statement fee rate type. For a full list of values see `OBInternalStatementFeeRateType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+      description: This code indicates the specific type of fee rate (e.g., AER, EAR). For a full list of values see `OBInternalStatementFeeRateType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string
       example: UK.OBIE.AER
       x-namespaced-enum:
@@ -6481,7 +6481,7 @@ components:
         - UK.OBIE.Weekly
         - UK.OBIE.Yearly
     OBInternalStatementInterestRateType1Code:
-      description: Description that may be available for the statement Interest rate type.
+      description: This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross).
       type: string
       example: UK.OBIE.FixedRate
       x-namespaced-enum:


### PR DESCRIPTION
- Description for `OBReadStatement2/Data/Statement/StatementFee/RateType` changed to "This code indicates the specific type of fee rate (e.g., AER, EAR)"
- Description for `OBReadStatement2/Data/Statement/StatementInterest/RateType` changed to "This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross)"