### PR TITLE
Updated descriptions & added examples

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -6,12 +6,14 @@
 
 - Added `LWMH`, `LXMH`, & `TWYR` to `OBFrequency6Code` in AIS and PIS
 - Added `SLCT` to `OBFrequency2` in AIS
+- Added example values to `fromBookingDateTime`, `toBookingDateTime`, `fromStatementDateTime` and `toStatementDateTime`.
 
 ### Changed
 
 - Updated example value in Error responses from `AC17` to `U001` in AIS and Events
 - [CDRW-4948] Description for `OBReadStatement2/Data/Statement/StatementFee/RateType` changed to "This code indicates the specific type of fee rate (e.g., AER, EAR)"
 - [CDRW-4948] Description for `OBReadStatement2/Data/Statement/StatementInterest/RateType` changed to "This code specifies the type of interest (e.g., BOE Base Rate, Fixed Rate, Gross)"
+- [CDRW-4949] Updated descriptions for `fromBookingDateTime`, `toBookingDateTime`, `fromStatementDateTime` and `toStatementDateTime` to clarify that the timezone component **must not** be present, as per the Spec pages.
 
 ## v4.0.1 Release Candidate 1 - 2026-01-05
 

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -1996,37 +1996,41 @@
       "FromBookingDateTimeParam": {
         "in": "query",
         "name": "fromBookingDateTime",
-        "description": "The UTC ISO 8601 Date Time to filter transactions FROM\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component.",
+        "description": "The UTC ISO 8601 Date Time to filter transactions FROM.\n\nNote: Time component is optional - set to 00:00:00 for just Date.\n\nThe value **must not** include the timezone component.\n",
         "schema": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "example": "2026-01-01T00:00:00"
         }
       },
       "ToBookingDateTimeParam": {
         "in": "query",
         "name": "toBookingDateTime",
-        "description": "The UTC ISO 8601 Date Time to filter transactions TO\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component.",
+        "description": "The UTC ISO 8601 Date Time to filter transactions TO.\n\nNote: Time component is optional - set to 00:00:00 for just Date.\n\nThe value **must not** include the timezone component.\n",
         "schema": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "example": "2026-12-31T23:59:59"
         }
       },
       "FromStatementDateTimeParam": {
         "in": "query",
         "name": "fromStatementDateTime",
-        "description": "The UTC ISO 8601 Date Time to filter statements FROM\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component.",
+        "description": "The UTC ISO 8601 Date Time to filter statements FROM.\n\nNote: Time component is optional - set to 00:00:00 for just Date.\n\nThe value **must not** include the timezone component.\n",
         "schema": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "example": "2026-01-01T00:00:00"
         }
       },
       "ToStatementDateTimeParam": {
         "in": "query",
         "name": "toStatementDateTime",
-        "description": "The UTC ISO 8601 Date Time to filter statements TO\nNB Time component is optional - set to 00:00:00 for just Date.\nIf the Date Time contains a timezone, the ASPSP must ignore the timezone component.",
+        "description": "The UTC ISO 8601 Date Time to filter statements TO.\n\nNote: Time component is optional - set to 00:00:00 for just Date.\n\nThe value **must not** include the timezone component.\n",
         "schema": {
           "type": "string",
-          "format": "date-time"
+          "format": "date-time",
+          "example": "2026-12-31T23:59:59"
         }
       },
       "ConsentId": {

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -1066,55 +1066,55 @@ components:
     FromBookingDateTimeParam:
       in: query
       name: fromBookingDateTime
-      description: >-
-        The UTC ISO 8601 Date Time to filter transactions FROM
+      description: |
+        The UTC ISO 8601 Date Time to filter transactions FROM.
 
-        NB Time component is optional - set to 00:00:00 for just Date.
+        Note: Time component is optional - set to 00:00:00 for just Date.
 
-        If the Date Time contains a timezone, the ASPSP must ignore the timezone
-        component.
+        The value **must not** include the timezone component.
       schema:
         type: string
         format: date-time
+        example: '2026-01-01T00:00:00'
     ToBookingDateTimeParam:
       in: query
       name: toBookingDateTime
-      description: >-
-        The UTC ISO 8601 Date Time to filter transactions TO
+      description: |
+        The UTC ISO 8601 Date Time to filter transactions TO.
 
-        NB Time component is optional - set to 00:00:00 for just Date.
+        Note: Time component is optional - set to 00:00:00 for just Date.
 
-        If the Date Time contains a timezone, the ASPSP must ignore the timezone
-        component.
+        The value **must not** include the timezone component.
       schema:
         type: string
         format: date-time
+        example: '2026-12-31T23:59:59'
     FromStatementDateTimeParam:
       in: query
       name: fromStatementDateTime
-      description: >-
-        The UTC ISO 8601 Date Time to filter statements FROM
+      description: |
+        The UTC ISO 8601 Date Time to filter statements FROM.
 
-        NB Time component is optional - set to 00:00:00 for just Date.
+        Note: Time component is optional - set to 00:00:00 for just Date.
 
-        If the Date Time contains a timezone, the ASPSP must ignore the timezone
-        component.
+        The value **must not** include the timezone component.
       schema:
         type: string
         format: date-time
+        example: '2026-01-01T00:00:00'
     ToStatementDateTimeParam:
       in: query
       name: toStatementDateTime
-      description: >-
-        The UTC ISO 8601 Date Time to filter statements TO
+      description: |
+        The UTC ISO 8601 Date Time to filter statements TO.
 
-        NB Time component is optional - set to 00:00:00 for just Date.
+        Note: Time component is optional - set to 00:00:00 for just Date.
 
-        If the Date Time contains a timezone, the ASPSP must ignore the timezone
-        component.
+        The value **must not** include the timezone component.
       schema:
         type: string
         format: date-time
+        example: '2026-12-31T23:59:59'
     ConsentId:
       name: ConsentId
       in: path


### PR DESCRIPTION
- Added example values to `fromBookingDateTime`, `toBookingDateTime`, `fromStatementDateTime` and `toStatementDateTime`.
- Updated descriptions for `fromBookingDateTime`, `toBookingDateTime`, `fromStatementDateTime` and `toStatementDateTime` to clarify that the timezone component **must not** be present, as per the Spec pages.