### PR TITLE
[CDRW-4136] Updated ErrorCode description

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -9,7 +9,7 @@
 
 ### Changed
 
-- [CDRW-4136] Updated `ErrorCode` $ref in PIS to use to `OBExternalStatusReason1Code`, matching rest of OpenAPI files (previously used `OBInternalErrorResponseError1Code`)
+- [CDRW-4136] Updated `ErrorCode` $ref in PIS to use `OBExternalStatusReason1Code`, matching rest of OpenAPI files (previously used `OBInternalErrorResponseError1Code`)
 
 ## v4.0.1 Release Candidate 2 - 2026-02-04
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+
+## Unreleased
+
+### Fixed
+
+- [CDRW-4136] Updated description of `OBExternalStatusReason1Code` to point to correct codeset name in AIS, PIS, CBPII, Events and VRP.
+
+### Changed
+
+- [CDRW-4136] Updated `ErrorCode` $ref in PIS to use to `OBExternalStatusReason1Code`, matching rest of OpenAPI files (previously used `OBInternalErrorResponseError1Code`)
+
 ## v4.0.1 Release Candidate 2 - 2026-02-04
 
 ### Added

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -7972,7 +7972,7 @@
         ]
       },
       "OBExternalStatusReason1Code": {
-        "description": "Low level textual error code, for all enum values see `ExternalReason1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "minLength": 4,
         "maxLength": 4,

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -6590,7 +6590,7 @@ components:
     OBExternalStatusReason1Code:
       description: >-
         Low level textual error code, for all enum values see
-        `ExternalReason1Code`
+        `OBExternalStatusReason1Code` in *OB_Internal_CodeSet*
         [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string
       minLength: 4

--- a/dist/openapi/confirmation-funds-openapi.json
+++ b/dist/openapi/confirmation-funds-openapi.json
@@ -1201,7 +1201,7 @@
         "additionalProperties": false
       },
       "OBExternalStatusReason1Code": {
-        "description": "Low level textual error code, for all enum values see `ExternalReturnReason1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "minLength": 4,
         "maxLength": 4,

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -991,7 +991,7 @@ components:
     OBExternalStatusReason1Code:
       description: >-
         Low level textual error code, for all enum values see
-        `ExternalReturnReason1Code`
+        `OBExternalStatusReason1Code` in *OB_Internal_CodeSet*
         [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string
       minLength: 4

--- a/dist/openapi/events-openapi.json
+++ b/dist/openapi/events-openapi.json
@@ -1203,7 +1203,7 @@
         "additionalProperties": false
       },
       "OBExternalStatusReason1Code": {
-        "description": "Low level textual error code, for all enum values see `ExternalReturnReason1Code` here - https://github.com/OpenBankingUK/External_Interal_CodeSets/",
+        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Interal_CodeSets/)",
         "type": "string",
         "minLength": 4,
         "maxLength": 4,

--- a/dist/openapi/events-openapi.yaml
+++ b/dist/openapi/events-openapi.yaml
@@ -874,8 +874,8 @@ components:
     OBExternalStatusReason1Code:
       description: >-
         Low level textual error code, for all enum values see
-        `ExternalReturnReason1Code` here -
-        https://github.com/OpenBankingUK/External_Interal_CodeSets/
+        `OBExternalStatusReason1Code` in *OB_Internal_CodeSet*
+        [here](https://github.com/OpenBankingUK/External_Interal_CodeSets/)
       type: string
       minLength: 4
       maxLength: 4

--- a/dist/openapi/payment-initiation-openapi.json
+++ b/dist/openapi/payment-initiation-openapi.json
@@ -5922,7 +5922,7 @@
         "type": "object",
         "properties": {
           "ErrorCode": {
-            "$ref": "#/components/schemas/OBInternalErrorResponseError1Code"
+            "$ref": "#/components/schemas/OBExternalStatusReason1Code"
           },
           "Message": {
             "description": "A description of the error that occurred. e.g., 'A mandatory field isn't supplied' or 'RequestedExecutionDateTime must be in future'\nOBL doesn't standardise this field",
@@ -6424,8 +6424,8 @@
           "CRYP"
         ]
       },
-      "OBInternalErrorResponseError1Code": {
-        "description": "Low level textual error code, for all enum values see `OBInternalErrorResponseError1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+      "OBExternalStatusReason1Code": {
+        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "minLength": 4,
         "maxLength": 4,

--- a/dist/openapi/payment-initiation-openapi.yaml
+++ b/dist/openapi/payment-initiation-openapi.yaml
@@ -3896,7 +3896,7 @@ components:
       type: object
       properties:
         ErrorCode:
-          $ref: '#/components/schemas/OBInternalErrorResponseError1Code'
+          $ref: '#/components/schemas/OBExternalStatusReason1Code'
         Message:
           description: >-
             A description of the error that occurred. e.g., 'A mandatory field
@@ -4396,10 +4396,10 @@ components:
         - RETL
         - DEBT
         - CRYP
-    OBInternalErrorResponseError1Code:
+    OBExternalStatusReason1Code:
       description: >-
         Low level textual error code, for all enum values see
-        `OBInternalErrorResponseError1Code`
+        `OBExternalStatusReason1Code` in *OB_Internal_CodeSet*
         [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string
       minLength: 4

--- a/dist/openapi/vrp-openapi.json
+++ b/dist/openapi/vrp-openapi.json
@@ -1658,7 +1658,7 @@
         ]
       },
       "OBExternalStatusReason1Code": {
-        "description": "Low level textual error code, for all enum values see `ExternalReturnReason1Code` [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "minLength": 4,
         "maxLength": 4,

--- a/dist/openapi/vrp-openapi.yaml
+++ b/dist/openapi/vrp-openapi.yaml
@@ -1164,7 +1164,7 @@ components:
     OBExternalStatusReason1Code:
       description: >-
         Low level textual error code, for all enum values see
-        `ExternalReturnReason1Code`
+        `OBExternalStatusReason1Code` in *OB_Internal_CodeSet*
         [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string
       minLength: 4


### PR DESCRIPTION
- Updated description of `OBExternalStatusReason1Code` to point to correct codeset name in AIS, PIS, CBPII, Events and VRP.
- Updated `ErrorCode` $ref in PIS to use `OBExternalStatusReason1Code`, matching rest of OpenAPI files (previously used `OBInternalErrorResponseError1Code`)