### PR TITLE
Fix typos

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -67,8 +67,7 @@
   - This is used in `OBReadTransaction6/Data/Transaction`
   - Returning these fields requires use of the `ReadTransactionDetail` permission
 - [v40_KI25] Deprecated `PaymentContextCode` values have been reintroduced to VRP and PIS OpenAPI files.
-  - For the avoidance of doubt - these values __must not__ be accepted in a new consent and may only be accepted for 
-    payment against a v3 VRP consent migrated to v4.
+  - For the avoidance of doubt - these values **must not** be accepted in a new consent and may only be accepted for payment against a v3 VRP consent migrated to v4.
   - They may optionally be returned for a historical payment or consent migrated to v4 when using a `GET` request.
 - [v40_KI7] `OBDomesticRefundAccount1` class definition added to the Payment Initiation and VRP OpenAPI files.
 - [CDRW-5013] `HTTP 422` has been added as a response code - this should be used when a duplicate Idempotency code is submitted.

--- a/changelog.md
+++ b/changelog.md
@@ -6,14 +6,14 @@
 
 - [CDRW-4136] Updated description of `OBExternalStatusReason1Code` to point to correct codeset name in AIS, PIS, CBPII, Events and VRP.
 - [CDRW-5043] Corrected typos and improved description clarity across all OpenAPI specification files:
-  - Fixed double word "as as" to "as" in top-level description
-  - Corrected "dentification" to "Identification" in multiple field descriptions
-  - Fixed article usage: "an rate" to "a rate", "an servicing" to "a servicing", "an Callback" to "a Callback"
-  - Fixed spelling errors: "crebit" to "credit", "memebership" to "membership", "statments" to "statements", "reefer" to "refer", "lust" to "list"
-  - Corrected GitHub URL typo: "External_Interal_CodeSets" to "External_Internal_CodeSets"
-  - Fixed whitespace artifacts in descriptions (removed escaped underscores)
-  - Improved grammar: "AWAU and RJCT only can returned" to "Only AWAU and RJCT can be returned"
-  - Clarified wording: "can not" to "cannot", "this include" to "this includes"
+  - Fixed double word "as as" to "as" in top-level description (AIS, CBPII, Events, PIS, VRP)
+  - Corrected "dentification" to "Identification" in multiple field descriptions (AIS)
+  - Fixed article usage: "an rate" to "a rate" (AIS), "an servicing" to "a servicing" (AIS, PIS, VRP), and "an Callback" to "a Callback" (Events)
+  - Fixed spelling errors: "crebit" to "credit" (AIS), "memebership" to "membership" (AIS), "statments" to "statements" (AIS), "reefer" to "refer" (PIS), "lust" to "list" (VRP)
+  - Corrected GitHub URL typo: "External_Interal_CodeSets" to "External_Internal_CodeSets" (Events)
+  - Fixed whitespace artifacts in descriptions (removed escaped underscores) (Events)
+  - Improved grammar: "AWAU and RJCT only can returned" to "Only AWAU and RJCT can be returned" (VRP)
+  - Clarified wording: "can not" to "cannot" (VRP), "this include" to "this includes" (VRP)
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,15 @@
 ### Fixed
 
 - [CDRW-4136] Updated description of `OBExternalStatusReason1Code` to point to correct codeset name in AIS, PIS, CBPII, Events and VRP.
+- [CDRW-5043] Corrected typos and improved description clarity across all OpenAPI specification files:
+  - Fixed double word "as as" to "as" in top-level description
+  - Corrected "dentification" to "Identification" in multiple field descriptions
+  - Fixed article usage: "an rate" to "a rate", "an servicing" to "a servicing", "an Callback" to "a Callback"
+  - Fixed spelling errors: "crebit" to "credit", "memebership" to "membership", "statments" to "statements", "reefer" to "refer", "lust" to "list"
+  - Corrected GitHub URL typo: "External_Interal_CodeSets" to "External_Internal_CodeSets"
+  - Fixed whitespace artifacts in descriptions (removed escaped underscores)
+  - Improved grammar: "AWAU and RJCT only can returned" to "Only AWAU and RJCT can be returned"
+  - Clarified wording: "can not" to "cannot", "this include" to "this includes"
 
 ### Changed
 

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Account and Transaction API Specification",
-    "description": "Swagger for Account and Transaction API Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.\n",
+    "description": "Swagger for Account and Transaction API Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.\n",
     "termsOfService": "https://www.openbanking.org.uk/terms",
     "contact": {
       "name": "Service Desk",
@@ -3429,7 +3429,7 @@
             "$ref": "#/components/schemas/ExternalDocumentType1Code"
           },
           "Issuer": {
-            "description": "dentification of the issuer of the reference document type.",
+            "description": "Identification of the issuer of the reference document type.",
             "type": "string",
             "maxLength": 140,
             "minLength": 1
@@ -3911,7 +3911,7 @@
         "maxLength": 256
       },
       "Identification_4": {
-        "description": "dentification of the party to whom an invoice is issued, when it is different from the debtor or ultimate debtor.",
+        "description": "Identification of the party to whom an invoice is issued, when it is different from the debtor or ultimate debtor.",
         "type": "string",
         "example": "80200112344562",
         "minLength": 1,
@@ -6559,13 +6559,13 @@
                             "pattern": "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
                           },
                           "MinimumRate": {
-                            "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)",
+                            "description": "Minimum rate on which fee/charge is applicable(where it is expressed as a rate)",
                             "title": "MinimumRate",
                             "type": "string",
                             "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                           },
                           "MaximumRate": {
-                            "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)",
+                            "description": "Maximum rate on which fee/charge is applicable(where it is expressed as a rate)",
                             "title": "MaximumRate",
                             "type": "string",
                             "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
@@ -7004,7 +7004,7 @@
       },
       "OBCashAccount6_1": {
         "type": "object",
-        "description": "Unambiguous identification of the account of the debtor, in the case of a crebit transaction.",
+        "description": "Unambiguous identification of the account of the debtor, in the case of a credit transaction.",
         "properties": {
           "SchemeName": {
             "$ref": "#/components/schemas/OBInternalAccountIdentification4Code"
@@ -8022,7 +8022,7 @@
           "Reason": {
             "description": "Reason for the setup of the credit transfer mandate.",
             "type": "string",
-            "example": "To pay monthly memebership",
+            "example": "To pay monthly membership",
             "maxLength": 256,
             "minLength": 1
           }
@@ -10047,13 +10047,13 @@
                           "pattern": "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
                         },
                         "MinimumRate": {
-                          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)",
+                          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as a rate)",
                           "title": "MinimumRate",
                           "type": "string",
                           "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                         },
                         "MaximumRate": {
-                          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)",
+                          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as a rate)",
                           "title": "MaximumRate",
                           "type": "string",
                           "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
@@ -12942,12 +12942,12 @@
                                           "pattern": "^(-?\\d{1,14}){1}(\\.\\d{1,4}){0,1}$"
                                         },
                                         "MinimumRate": {
-                                          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as an rate)",
+                                          "description": "Minimum rate on which fee/charge is applicable(where it is expressed as a rate)",
                                           "type": "string",
                                           "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                                         },
                                         "MaximumRate": {
-                                          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as an rate)",
+                                          "description": "Maximum rate on which fee/charge is applicable(where it is expressed as a rate)",
                                           "type": "string",
                                           "pattern": "^(-?\\d{1,3}){1}(\\.\\d{1,4}){0,1}$"
                                         }
@@ -15220,7 +15220,7 @@
         "type": "array",
         "items": {
           "type": "object",
-          "description": "Frequency and format of statments for an account",
+          "description": "Frequency and format of statements for an account",
           "properties": {
             "Frequency": {
               "$ref": "#/components/schemas/OBFrequency2"
@@ -15238,7 +15238,7 @@
         }
       },
       "StatementId": {
-        "description": "Unique identifier for the statement resource within an servicing institution. This identifier is both unique and immutable.",
+        "description": "Unique identifier for the statement resource within a servicing institution. This identifier is both unique and immutable.",
         "type": "string",
         "example": "8sfhke-sifhkeuf-97813",
         "minLength": 1,
@@ -15276,7 +15276,7 @@
         "maxLength": 140
       },
       "TransactionId": {
-        "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.",
+        "description": "Unique identifier for the transaction within a servicing institution. This identifier is both unique and immutable.",
         "type": "string",
         "minLength": 1,
         "maxLength": 210

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Swagger for Account and Transaction API Specification.
     
-    **Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.
+    **Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.
   termsOfService: https://www.openbanking.org.uk/terms
   contact:
     name: Service Desk
@@ -2071,7 +2071,7 @@ components:
         Code:
           $ref: '#/components/schemas/ExternalDocumentType1Code'
         Issuer:
-          description: 'dentification of the issuer of the reference document type.'
+          description: 'Identification of the issuer of the reference document type.'
           type: string
           maxLength: 140
           minLength: 1
@@ -2650,7 +2650,7 @@ components:
       maxLength: 256
     Identification_4:
       description: >-
-        dentification of the party to whom an invoice is issued, when it is different from the debtor or ultimate debtor.
+        Identification of the party to whom an invoice is issued, when it is different from the debtor or ultimate debtor.
       type: string
       example: '80200112344562'
       minLength: 1
@@ -5279,14 +5279,14 @@ components:
                         MinimumRate:
                           description: >-
                             Minimum rate on which fee/charge is applicable(where
-                            it is expressed as an rate)
+                            it is expressed as a rate)
                           title: MinimumRate
                           type: string
                           pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
                         MaximumRate:
                           description: >-
                             Maximum rate on which fee/charge is applicable(where
-                            it is expressed as an rate)
+                            it is expressed as a rate)
                           title: MaximumRate
                           type: string
                           pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
@@ -5646,7 +5646,7 @@ components:
       type: object
       description: >-
         Unambiguous identification of the account of the debtor, in the case of
-        a crebit transaction.
+        a credit transaction.
       properties:
         SchemeName:
           $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
@@ -6651,7 +6651,7 @@ components:
         Reason:
           description: Reason for the setup of the credit transfer mandate.
           type: string
-          example: To pay monthly memebership
+          example: To pay monthly membership
           maxLength: 256
           minLength: 1
     OBMerchantDetails1:
@@ -8705,14 +8705,14 @@ components:
                       MinimumRate:
                         description: >-
                           Minimum rate on which fee/charge is applicable(where
-                          it is expressed as an rate)
+                          it is expressed as a rate)
                         title: MinimumRate
                         type: string
                         pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
                       MaximumRate:
                         description: >-
                           Maximum rate on which fee/charge is applicable(where
-                          it is expressed as an rate)
+                          it is expressed as a rate)
                         title: MaximumRate
                         type: string
                         pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
@@ -11415,14 +11415,14 @@ components:
                                       MinimumRate:
                                         description: >-
                                           Minimum rate on which fee/charge is
-                                          applicable(where it is expressed as an
+                                          applicable(where it is expressed as a
                                           rate)
                                         type: string
                                         pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
                                       MaximumRate:
                                         description: >-
                                           Maximum rate on which fee/charge is
-                                          applicable(where it is expressed as an
+                                          applicable(where it is expressed as a
                                           rate)
                                         type: string
                                         pattern: '^(-?\d{1,3}){1}(\.\d{1,4}){0,1}$'
@@ -13248,7 +13248,7 @@ components:
       type: array
       items:
         type: object
-        description: Frequency and format of statments for an account
+        description: Frequency and format of statements for an account
         properties:
           Frequency:
             $ref: '#/components/schemas/OBFrequency2'
@@ -13260,7 +13260,7 @@ components:
             $ref: '#/components/schemas/OBPostalAddress7'
     StatementId:
       description: >-
-        Unique identifier for the statement resource within an servicing
+        Unique identifier for the statement resource within a servicing
         institution. This identifier is both unique and immutable.
       type: string
       example: 8sfhke-sifhkeuf-97813
@@ -13322,7 +13322,7 @@ components:
       maxLength: 140
     TransactionId:
       description: >-
-        Unique identifier for the transaction within an servicing institution.
+        Unique identifier for the transaction within a servicing institution.
         This identifier is both unique and immutable.
       type: string
       minLength: 1

--- a/dist/openapi/confirmation-funds-openapi.json
+++ b/dist/openapi/confirmation-funds-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Confirmation of Funds API Specification",
-    "description": "Swagger for Confirmation of Funds API Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.\n",
+    "description": "Swagger for Confirmation of Funds API Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.\n",
     "termsOfService": "https://www.openbanking.org.uk/terms",
     "contact": {
       "name": "Service Desk",

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Swagger for Confirmation of Funds API Specification.
     
-    **Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.
+    **Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.
   termsOfService: https://www.openbanking.org.uk/terms
   contact:
     name: Service Desk

--- a/dist/openapi/event-notifications-openapi.json
+++ b/dist/openapi/event-notifications-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Event Notification API Specification - TPP Endpoints",
-    "description": "Swagger for Event Notification API Specification - TPP Endpoints.\n\n**Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.\n",
+    "description": "Swagger for Event Notification API Specification - TPP Endpoints.\n\n**Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.\n",
     "termsOfService": "https://www.openbanking.org.uk/terms",
     "contact": {
       "name": "Service Desk",
@@ -39,7 +39,7 @@
               }
             }
           },
-          "description": "Create an Callback URI",
+          "description": "Create a Callback URI",
           "required": true
         },
         "responses": {

--- a/dist/openapi/event-notifications-openapi.yaml
+++ b/dist/openapi/event-notifications-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Swagger for Event Notification API Specification - TPP Endpoints.
     
-    **Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.
+    **Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.
   termsOfService: https://www.openbanking.org.uk/terms
   contact:
     name: Service Desk
@@ -29,7 +29,7 @@ paths:
             schema:
               type: string
               format: base64
-        description: Create an Callback URI
+        description: Create a Callback URI
         required: true
       responses:
         '202':

--- a/dist/openapi/events-openapi.json
+++ b/dist/openapi/events-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Events API Specification - ASPSP Endpoints",
-    "description": "OpenAPI for Events (Subscription & Aggregated Polling) API Specification - ASPSP Endpoints.\n\n**Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.\n",
+    "description": "OpenAPI for Events (Subscription & Aggregated Polling) API Specification - ASPSP Endpoints.\n\n**Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.\n",
     "termsOfService": "https://www.openbanking.org.uk/terms",
     "contact": {
       "name": "Service Desk",
@@ -1144,7 +1144,7 @@
           "ack": {
             "type": "array",
             "items": {
-              "description": "An array of jti values indicating event notifications positively acknowledged by the TPP",
+              "description": "An array of jti values indicating event notifications positively acknowledged by the TPP",
               "type": "string",
               "minLength": 1,
               "maxLength": 128
@@ -1195,7 +1195,7 @@
             "description": "A JSON object that contains zero or more nested JSON attributes. If there are no outstanding event notifications to be transmitted, the JSON object SHALL be empty.",
             "properties": {},
             "additionalProperties": {
-              "description": "An object named with the jti of the event notification to be delivered. The value is the event notification, expressed as a string.\nThe payload of the event should be defined in the OBEventNotification2 format.",
+              "description": "An object named with the jti of the event notification to be delivered. The value is the event notification, expressed as a string.\nThe payload of the event should be defined in the OBEventNotification2 format.",
               "type": "string"
             }
           }
@@ -1203,7 +1203,7 @@
         "additionalProperties": false
       },
       "OBExternalStatusReason1Code": {
-        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Interal_CodeSets/)",
+        "description": "Low level textual error code, for all enum values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/)",
         "type": "string",
         "minLength": 4,
         "maxLength": 4,

--- a/dist/openapi/events-openapi.yaml
+++ b/dist/openapi/events-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     OpenAPI for Events (Subscription & Aggregated Polling) API Specification - ASPSP Endpoints.
     
-    **Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.
+    **Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.
   termsOfService: https://www.openbanking.org.uk/terms
   contact:
     name: Service Desk
@@ -816,7 +816,7 @@ components:
         ack:
           type: array
           items:
-            description: "An array of jti\_values indicating event notifications positively acknowledged by the TPP"
+            description: "An array of jti values indicating event notifications positively acknowledged by the TPP"
             type: string
             minLength: 1
             maxLength: 128
@@ -868,14 +868,14 @@ components:
             JSON object SHALL be empty.
           properties: {}
           additionalProperties:
-            description: "An object named with the jti\_of the\_event notification to be delivered. The value is the event notification, expressed as a\_string.\nThe payload of the event should be defined in the OBEventNotification2\_format."
+            description: "An object named with the jti of the event notification to be delivered. The value is the event notification, expressed as a string.\nThe payload of the event should be defined in the OBEventNotification2 format."
             type: string
       additionalProperties: false
     OBExternalStatusReason1Code:
       description: >-
         Low level textual error code, for all enum values see
         `OBExternalStatusReason1Code` in *OB_Internal_CodeSet*
-        [here](https://github.com/OpenBankingUK/External_Interal_CodeSets/)
+        [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/)
       type: string
       minLength: 4
       maxLength: 4

--- a/dist/openapi/payment-initiation-openapi.json
+++ b/dist/openapi/payment-initiation-openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.0",
   "info": {
     "title": "Payment Initiation API",
-    "description": "Swagger for Payment Initiation API Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.\n",
+    "description": "Swagger for Payment Initiation API Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.\n",
     "termsOfService": "https://www.openbanking.org.uk/terms",
     "contact": {
       "name": "Service Desk",
@@ -6773,7 +6773,7 @@
         "properties": {
           "DebitCreditReportingIndicator": {
             "type": "string",
-            "description": "Identifies whether the regulatory reporting information applies to the debit side, to the credit side or to both debit and credit sides of the transaction.  For a full list of values reefer to `OBExternalRegulatoryReportingType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+            "description": "Identifies whether the regulatory reporting information applies to the debit side, to the credit side or to both debit and credit sides of the transaction.  For a full list of values refer to `OBExternalRegulatoryReportingType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
             "enum": [
               "CRED",
               "DEBT",
@@ -6853,7 +6853,7 @@
         "properties": {
           "RequestedSCAExemptionType": {
             "type": "string",
-            "description": "This field allows a PISP to request specific SCA Exemption for a Payment Initiation. For a full list of values reefer to `OBInternalSCAExemptionType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+            "description": "This field allows a PISP to request specific SCA Exemption for a Payment Initiation. For a full list of values refer to `OBInternalSCAExemptionType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
             "enum": [
               "BillPayment",
               "ContactlessTravel",
@@ -14352,7 +14352,7 @@
             "type": "string",
             "minLength": 1,
             "maxLength": 210,
-            "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+            "description": "Unique identifier for the transaction within a servicing institution. This identifier is both unique and immutable."
           },
           "Status": {
             "$ref": "#/components/schemas/ExternalPaymentTransactionStatus1Code"

--- a/dist/openapi/payment-initiation-openapi.yaml
+++ b/dist/openapi/payment-initiation-openapi.yaml
@@ -4,7 +4,7 @@ info:
   description: |
     Swagger for Payment Initiation API Specification.
     
-    **Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.
+    **Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.
   termsOfService: https://www.openbanking.org.uk/terms
   contact:
     name: Service Desk
@@ -4705,7 +4705,7 @@ components:
             Identifies whether the regulatory reporting information applies to
             the debit side, to the credit side or to both debit and credit sides
             of the transaction. 
-            For a full list of values reefer to `OBExternalRegulatoryReportingType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+            For a full list of values refer to `OBExternalRegulatoryReportingType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
           enum:
             - CRED
             - DEBT
@@ -4783,7 +4783,7 @@ components:
           type: string
           description: >-
             This field allows a PISP to request specific SCA Exemption for a
-            Payment Initiation. For a full list of values reefer to `OBInternalSCAExemptionType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+            Payment Initiation. For a full list of values refer to `OBInternalSCAExemptionType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
           enum:
             - BillPayment
             - ContactlessTravel
@@ -12700,7 +12700,7 @@ components:
           minLength: 1
           maxLength: 210
           description: >-
-            Unique identifier for the transaction within an servicing
+            Unique identifier for the transaction within a servicing
             institution. This identifier is both unique and immutable.
         Status:
           $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code'

--- a/dist/openapi/vrp-openapi.json
+++ b/dist/openapi/vrp-openapi.json
@@ -7,7 +7,7 @@
   ],
   "info": {
     "title": "OBL VRP Profile",
-    "description": "VRP OpenAPI Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.\n",
+    "description": "VRP OpenAPI Specification.\n\n**Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.\n",
     "version": "4.0.1",
     "termsOfService": "https://www.openbanking.org.uk/terms",
     "contact": {
@@ -1745,7 +1745,7 @@
         }
       },
       "OBInternalConsentStatus1Code": {
-        "description": "Specifies the status of consent resource in code form. AWAU and RJCT only can returned on initial submission. For a full list of values see `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Specifies the status of consent resource in code form. Only AWAU and RJCT can be returned on initial submission. For a full list of values see `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "enum": [
           "AWAU",
@@ -1842,7 +1842,7 @@
                     "Consent",
                     "Calendar"
                   ],
-                  "description": "Specifies whether the period starts on the date of consent creation or lines up with a calendar. As the ISO calendar does not support or provide any guidance on when a fortnight should start, a `PeriodType` of `Fortnight` the `PeriodAlignment` must be `Consent`."
+                  "description": "Specifies whether the period starts on the date of consent creation or lines up with a calendar. As the ISO calendar does not support or provide any guidance on when a fortnight should start, when specifying a `PeriodType` of `Fortnight` the `PeriodAlignment` must be `Consent`."
                 },
                 "Amount": {
                   "$ref": "#/components/schemas/OBActiveCurrencyAndAmount_SimpleType"
@@ -1859,7 +1859,7 @@
               "$ref": "#/components/schemas/OBVRPConsentType"
             },
             "minItems": 1,
-            "description": "^ The types of payments that can be made under this VRP consent. This can be used to indicate whether this include sweeping payment or other ecommerce payments."
+            "description": "^ The types of payments that can be made under this VRP consent. This can be used to indicate whether this includes sweeping payments or other ecommerce payments."
           },
           "PSUAuthenticationMethods": {
             "type": "array",
@@ -1878,7 +1878,7 @@
           },
           "SupplementaryData": {
             "type": "object",
-            "description": "^ Additional information that can not be captured in the structured fields and/or any other specific block"
+            "description": "^ Additional information that cannot be captured in the structured fields and/or any other specific block"
           }
         }
       },
@@ -2196,7 +2196,7 @@
                       "type": "string",
                       "minLength": 1,
                       "maxLength": 210,
-                      "description": "Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable."
+                      "description": "Unique identifier for the transaction within a servicing institution. This identifier is both unique and immutable."
                     },
                     "Status": {
                       "$ref": "#/components/schemas/ExternalPaymentTransactionStatus1Code"
@@ -2465,7 +2465,7 @@
           },
           "SupplementaryData": {
             "type": "object",
-            "description": "Additional information that can not be captured in the structured fields and/or any other specific block.\n"
+            "description": "Additional information that cannot be captured in the structured fields and/or any other specific block.\n"
           }
         }
       },
@@ -2662,7 +2662,7 @@
         "type": "string",
         "minLength": 1,
         "maxLength": 4,
-        "description": "Specifies the amount type, as published in an external referred amount code set. For a full lust of values refer to `ExternalCreditorReferenceType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Specifies the amount type, as published in an external referred amount code set. For a full list of values refer to `ExternalCreditorReferenceType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "enum": [
           "DISP",
           "FXDR",

--- a/dist/openapi/vrp-openapi.yaml
+++ b/dist/openapi/vrp-openapi.yaml
@@ -6,7 +6,7 @@ info:
   description: |
     VRP OpenAPI Specification.
     
-    **Please Note**: There are no optional fields, if a field is not marked as as “Required” it is a Conditional field.
+    **Please Note**: There are no optional fields, if a field is not marked as “Required” it is a Conditional field.
   version: 4.0.1
   termsOfService: https://www.openbanking.org.uk/terms
   contact:
@@ -1236,8 +1236,8 @@ components:
           $ref: '#/components/schemas/Meta'
     OBInternalConsentStatus1Code:
       description: >-
-        Specifies the status of consent resource in code form. AWAU and
-        RJCT only can returned on initial submission. For a full list of values see `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+        Specifies the status of consent resource in code form. Only AWAU and
+        RJCT can be returned on initial submission. For a full list of values see `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string
       enum:
         - AWAU
@@ -1315,7 +1315,7 @@ components:
                   - Consent
                   - Calendar
                 description: >-
-                  Specifies whether the period starts on the date of consent creation or lines up with a calendar. As the ISO calendar does not support or provide any guidance on when a fortnight should start, a `PeriodType` of `Fortnight` the `PeriodAlignment` must be `Consent`.
+                  Specifies whether the period starts on the date of consent creation or lines up with a calendar. As the ISO calendar does not support or provide any guidance on when a fortnight should start, when specifying a `PeriodType` of `Fortnight` the `PeriodAlignment` must be `Consent`.
               Amount:
                 $ref: '#/components/schemas/OBActiveCurrencyAndAmount_SimpleType'
               Currency:
@@ -1327,7 +1327,7 @@ components:
           minItems: 1
           description: >-
             ^ The types of payments that can be made under this VRP consent.
-            This can be used to indicate whether this include sweeping payment
+            This can be used to indicate whether this includes sweeping payments
             or other ecommerce payments.
         PSUAuthenticationMethods:
           type: array
@@ -1344,7 +1344,7 @@ components:
         SupplementaryData:
           type: object
           description: >-
-            ^ Additional information that can not be captured in the structured
+            ^ Additional information that cannot be captured in the structured
             fields and/or any other specific block
     OBDomesticVRPInitiation:
       type: object
@@ -1621,7 +1621,7 @@ components:
                     minLength: 1
                     maxLength: 210
                     description: |-
-                      Unique identifier for the transaction within an servicing institution. This identifier is both unique and immutable.
+                      Unique identifier for the transaction within a servicing institution. This identifier is both unique and immutable.
                   Status:
                     $ref: '#/components/schemas/ExternalPaymentTransactionStatus1Code'
                   StatusUpdateDateTime:
@@ -1874,7 +1874,7 @@ components:
         SupplementaryData:
           type: object
           description: >
-            Additional information that can not be captured in the structured
+            Additional information that cannot be captured in the structured
             fields and/or any other specific block.
     OBExternalCreditorReferenceType1Code:
       type: string
@@ -2041,7 +2041,7 @@ components:
       type: string
       minLength: 1
       maxLength: 4
-      description: "Specifies the amount type, as published in an external referred amount code set. For a full lust of values refer to `ExternalCreditorReferenceType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)"
+      description: "Specifies the amount type, as published in an external referred amount code set. For a full list of values refer to `ExternalCreditorReferenceType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)"
       enum:
         - DISP
         - FXDR


### PR DESCRIPTION
Corrected typos and improved description clarity across all OpenAPI specification files:
  - Fixed double word "as as" to "as" in top-level description
  - Corrected "dentification" to "Identification" in multiple field descriptions
  - Fixed article usage: "an rate" to "a rate", "an servicing" to "a servicing", "an Callback" to "a Callback"
  - Fixed spelling errors: "crebit" to "credit", "memebership" to "membership", "statments" to "statements", "reefer" to "refer", "lust" to "list"
  - Corrected GitHub URL typo: "External_Interal_CodeSets" to "External_Internal_CodeSets"
  - Fixed whitespace artifacts in descriptions (removed escaped underscores)
  - Improved grammar: "AWAU and RJCT only can returned" to "Only AWAU and RJCT can be returned"
  - Clarified wording: "can not" to "cannot", "this include" to "this includes"