### PR TITLE
feat(AIS): add CRYP to OBExternalPurpose1Code [CDRW-5005]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -19,6 +19,7 @@ For v4.0.1 the following approach has been adopted for identifying changes:
 ## Added
 
 - [CDRW-5045] Updated all ASPSP endpoints with descriptions describing their use.
+- [CDRW-5005] Added `CRYP` to `OBExternalPurpose1Code` in AIS to align with PIS, where `CRYP` (CryptoAssets) was already present as part of the CR4a change.
 
 ### Fixed
 

--- a/dist/openapi/account-info-openapi.json
+++ b/dist/openapi/account-info-openapi.json
@@ -7754,7 +7754,8 @@
           "CPEN",
           "DEPD",
           "RETL",
-          "DEBT"
+          "DEBT",
+          "CRYP"
         ]
       },
       "OBInternalScheduleType1Code": {

--- a/dist/openapi/account-info-openapi.yaml
+++ b/dist/openapi/account-info-openapi.yaml
@@ -6395,6 +6395,7 @@ components:
         - DEPD
         - RETL
         - DEBT
+        - CRYP
     OBInternalScheduleType1Code:
       description: Specifies the scheduled payment date type requested. For a full list of enumeration values refer to `OBInternalScheduleType1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
       type: string


### PR DESCRIPTION
## Summary

Adds `CRYP` (CryptoAssets) to `OBExternalPurpose1Code` in the AIS OpenAPI spec to align with the PIS spec, where `CRYP` was already present as part of the CR4a change in v4.0.1.

## Change Details

- **File**: `dist/openapi/account-info-openapi.yaml`
- **Schema**: `OBExternalPurpose1Code` enum
- **Value added**: `CRYP` (CryptoAssets — transaction is related to the purchase or sale of crypto assets)
- **Source**: Verified against the official [ISO External Codeset](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/v4.0.1/ISO_External_Codeset.csv)

## Changelog

Entry added under `v4.0.1 - Unreleased` > `Added`:
> [CDRW-5005] Added `CRYP` to `OBExternalPurpose1Code` in AIS to align with PIS, where `CRYP` (CryptoAssets) was already present as part of the CR4a change.

[CDRW-5005]: https://openbanking.atlassian.net/browse/CDRW-5005?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ