### PR TITLE
Update changelog for v4.0.1 release date

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -14,7 +14,7 @@ For v4.0.1 the following approach has been adopted for identifying changes:
 - [v4.0.1 Release Candidate 1](https://openbanking.atlassian.net/wiki/spaces/WOR/pages/4203282434/Feedback+-+v4.0.1+Release+Candidate+1)
 - [v4.0.1 Release Candidate 2](https://openbanking.atlassian.net/wiki/spaces/WOR/pages/4309942273/Feedback+-+v4.0.1+Release+Candidate+2)
 
-## v4.0.1 - Unreleased
+## v4.0.1 - 2026-04-01
 
 ### Added
 


### PR DESCRIPTION
This PR updates the changelog for v4.0.1, replacing 'Unreleased' with the release date 2026-04-01.