### PR TITLE
Refactor confirmation funds account ID enum

### DIFF
--- a/dist/openapi/confirmation-funds-openapi.json
+++ b/dist/openapi/confirmation-funds-openapi.json
@@ -756,20 +756,8 @@
           }
         }
       },
-      "OBInternalAccountIdentification4Code": {
-        "description": "Name of the identification scheme, in a coded form as published in an external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)",
-        "type": "string",
-        "x-namespaced-enum": [
-          "UK.OBIE.BBAN",
-          "UK.OBIE.IBAN",
-          "UK.OBIE.PAN",
-          "UK.OBIE.Paym",
-          "UK.OBIE.SortCodeAccountNumber",
-          "UK.OBIE.Wallet"
-        ]
-      },
       "ExternalProxyAccountType1Code": {
-        "description": "Specifies the external proxy account type code, as published in the proxy account type external code set.<br > For a full list of values refer to `ExternalProxyAccountType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/ISO_External_Codeset.csv)",
+        "description": "Specifies the external proxy account type code, as published in the proxy account type external code set.<br > For a full list of values refer to `ExternalProxyAccountType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "enum": [
           "TELE",
@@ -991,7 +979,16 @@
                 "description": "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.",
                 "properties": {
                   "SchemeName": {
-                    "$ref": "#/components/schemas/OBInternalAccountIdentification4Code"
+                    "description": "Name of the identification scheme, in a coded form as published in an external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+                    "type": "string",
+                    "x-namespaced-enum": [
+                      "UK.OBIE.BBAN",
+                      "UK.OBIE.IBAN",
+                      "UK.OBIE.PAN",
+                      "UK.OBIE.Paym",
+                      "UK.OBIE.SortCodeAccountNumber",
+                      "UK.OBIE.Wallet"
+                    ]
                   },
                   "Identification": {
                     "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner.",
@@ -1076,7 +1073,16 @@
                 "description": "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.",
                 "properties": {
                   "SchemeName": {
-                    "$ref": "#/components/schemas/OBInternalAccountIdentification4Code"
+                    "description": "Name of the identification scheme, in a coded form as published in an external list. For a full list of values refer to `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+                    "type": "string",
+                    "x-namespaced-enum": [
+                      "UK.OBIE.BBAN",
+                      "UK.OBIE.IBAN",
+                      "UK.OBIE.PAN",
+                      "UK.OBIE.Paym",
+                      "UK.OBIE.SortCodeAccountNumber",
+                      "UK.OBIE.Wallet"
+                    ]
                   },
                   "Identification": {
                     "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner.",
@@ -1113,7 +1119,7 @@
         "additionalProperties": false
       },
       "OBInternalConsentStatus1Code": {
-        "description": "Specifies the status of consent resource in code form. For a full list of values refer to `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)",
+        "description": "Specifies the status of consent resource in code form. For a full list of values refer to `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
         "type": "string",
         "enum": [
           "AWAU",

--- a/dist/openapi/confirmation-funds-openapi.json
+++ b/dist/openapi/confirmation-funds-openapi.json
@@ -756,8 +756,20 @@
           }
         }
       },
+      "OBInternalAccountIdentification4Code": {
+        "description": "Name of the identification scheme, in a coded form as published in an external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)",
+        "type": "string",
+        "x-namespaced-enum": [
+          "UK.OBIE.BBAN",
+          "UK.OBIE.IBAN",
+          "UK.OBIE.PAN",
+          "UK.OBIE.Paym",
+          "UK.OBIE.SortCodeAccountNumber",
+          "UK.OBIE.Wallet"
+        ]
+      },
       "ExternalProxyAccountType1Code": {
-        "description": "Specifies the external proxy account type code, as published in the proxy account type external code set.<br > For a full list of values refer to `ExternalProxyAccountType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Specifies the external proxy account type code, as published in the proxy account type external code set.<br > For a full list of values refer to `ExternalProxyAccountType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/ISO_External_Codeset.csv)",
         "type": "string",
         "enum": [
           "TELE",
@@ -979,16 +991,7 @@
                 "description": "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.",
                 "properties": {
                   "SchemeName": {
-                    "description": "Name of the identification scheme, in a coded form as published in an external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
-                    "type": "string",
-                    "x-namespaced-enum": [
-                      "UK.OBIE.BBAN",
-                      "UK.OBIE.IBAN",
-                      "UK.OBIE.PAN",
-                      "UK.OBIE.Paym",
-                      "UK.OBIE.SortCodeAccountNumber",
-                      "UK.OBIE.Wallet"
-                    ]
+                    "$ref": "#/components/schemas/OBInternalAccountIdentification4Code"
                   },
                   "Identification": {
                     "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner.",
@@ -1073,16 +1076,7 @@
                 "description": "Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.",
                 "properties": {
                   "SchemeName": {
-                    "description": "Name of the identification scheme, in a coded form as published in an external list. For a full list of values refer to `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
-                    "type": "string",
-                    "x-namespaced-enum": [
-                      "UK.OBIE.BBAN",
-                      "UK.OBIE.IBAN",
-                      "UK.OBIE.PAN",
-                      "UK.OBIE.Paym",
-                      "UK.OBIE.SortCodeAccountNumber",
-                      "UK.OBIE.Wallet"
-                    ]
+                    "$ref": "#/components/schemas/OBInternalAccountIdentification4Code"
                   },
                   "Identification": {
                     "description": "Identification assigned by an institution to identify an account. This identification is known by the account owner.",
@@ -1119,7 +1113,7 @@
         "additionalProperties": false
       },
       "OBInternalConsentStatus1Code": {
-        "description": "Specifies the status of consent resource in code form. For a full list of values refer to `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)",
+        "description": "Specifies the status of consent resource in code form. For a full list of values refer to `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)",
         "type": "string",
         "enum": [
           "AWAU",

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -556,9 +556,10 @@ components:
           minLength: 1
           maxLength: 35
     OBInternalAccountIdentification4Code:
-      description: >-
-        Name of the identification scheme, in a coded form as published in an
-        external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)
+      description: |-
+        Name of the identification scheme, in a coded form as published in an external list.
+
+        For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)
       type: string
       x-namespaced-enum:
         - UK.OBIE.BBAN

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -518,11 +518,23 @@ components:
           description: Type of the proxy identification.
           minLength: 1
           maxLength: 35
+    OBInternalAccountIdentification4Code:
+      description: >-
+        Name of the identification scheme, in a coded form as published in an
+        external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)
+      type: string
+      x-namespaced-enum:
+        - UK.OBIE.BBAN
+        - UK.OBIE.IBAN
+        - UK.OBIE.PAN
+        - UK.OBIE.Paym
+        - UK.OBIE.SortCodeAccountNumber
+        - UK.OBIE.Wallet
     ExternalProxyAccountType1Code:
       description: >-
         Specifies the external proxy account type code, as published in the
         proxy account type external code set.<br > For a full list of values refer to
-        `ExternalProxyAccountType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+        `ExternalProxyAccountType1Code` in *ISO_External_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/ISO_External_Codeset.csv)
       type: string
       enum:
         - TELE
@@ -739,17 +751,7 @@ components:
                 a confirmation of funds consent will be applied.
               properties:
                 SchemeName:
-                  description: >-
-                    Name of the identification scheme, in a coded form as
-                    published in an external list. For a full list of values see `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
-                  type: string
-                  x-namespaced-enum:
-                    - UK.OBIE.BBAN
-                    - UK.OBIE.IBAN
-                    - UK.OBIE.PAN
-                    - UK.OBIE.Paym
-                    - UK.OBIE.SortCodeAccountNumber
-                    - UK.OBIE.Wallet
+                  $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
                 Identification:
                   description: >-
                     Identification assigned by an institution to identify an
@@ -857,17 +859,7 @@ components:
                 a confirmation of funds consent will be applied.
               properties:
                 SchemeName:
-                  description: >-
-                    Name of the identification scheme, in a coded form as
-                    published in an external list. For a full list of values refer to `OBInternalAccountIdentification4Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
-                  type: string
-                  x-namespaced-enum:
-                    - UK.OBIE.BBAN
-                    - UK.OBIE.IBAN
-                    - UK.OBIE.PAN
-                    - UK.OBIE.Paym
-                    - UK.OBIE.SortCodeAccountNumber
-                    - UK.OBIE.Wallet
+                  $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
                 Identification:
                   description: >-
                     Identification assigned by an institution to identify an
@@ -905,7 +897,7 @@ components:
           $ref: '#/components/schemas/Meta'
       additionalProperties: false
     OBInternalConsentStatus1Code:
-      description: Specifies the status of consent resource in code form. For a full list of values refer to `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
+      description: Specifies the status of consent resource in code form. For a full list of values refer to `OBInternalConsentStatus1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets/blob/main/OB_Internal_Codeset.csv)
       type: string
       enum:
         - AWAU


### PR DESCRIPTION
The confirmation-of-funds spec repeated the same `OBInternalAccountIdentification4Code` enum inline, making it easier for future changes to drift between request and response schemas.

This extracts `OBInternalAccountIdentification4Code` into a reusable schema and updates both `DebtorAccount.SchemeName` definitions to reference it. The codeset descriptions now also link directly to the relevant source CSV files in `External_Internal_CodeSets`, while preserving the existing enum values in both YAML and JSON generated specs.