### PR TITLE
Add CBPII OpenAPI examples

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -21,6 +21,7 @@ For v4.0.1 the following approach has been adopted for identifying changes:
 - Added CBPII OpenAPI tags for `Funds Confirmation Consents` and `Funds Confirmations` to improve Swagger UI grouping and navigation.
 - Added optional `x-jws-signature` request header support across all CBPII operations to align with the Open Banking spec pages/standard.
 - Added optional `x-jws-signature` response header support across CBPII success and error responses to align with the Open Banking spec pages/standard.
+- Added reusable CBPII OpenAPI examples for successful request/response payloads, key parameters, and error payloads.
 
 ### Changed
 

--- a/changelog.md
+++ b/changelog.md
@@ -21,7 +21,7 @@ For v4.0.1 the following approach has been adopted for identifying changes:
 - Added CBPII OpenAPI tags for `Funds Confirmation Consents` and `Funds Confirmations` to improve Swagger UI grouping and navigation.
 - Added optional `x-jws-signature` request header support across all CBPII operations to align with the Open Banking spec pages/standard.
 - Added optional `x-jws-signature` response header support across CBPII success and error responses to align with the Open Banking spec pages/standard.
-- Added reusable CBPII OpenAPI examples for successful request/response payloads, key parameters, and error payloads.
+- Added CBPII OpenAPI examples for key parameters and schema fields.
 
 ### Changed
 

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -44,9 +44,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/OBFundsConfirmationConsent1'
-            examples:
-              FundsConfirmationConsentCreateRequest:
-                $ref: '#/components/examples/FundsConfirmationConsentCreateRequest'
         description: Default
         required: true
       responses:
@@ -179,11 +176,6 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/OBFundsConfirmation1'
-            examples:
-              FundsConfirmationCreateRequest:
-                $ref: '#/components/examples/FundsConfirmationCreateRequest'
-              FundsConfirmationUsdRequest:
-                $ref: '#/components/examples/FundsConfirmationUsdRequest'
         description: Default
         required: true
       responses:
@@ -326,165 +318,6 @@ components:
       schema:
         type: string
         example: eyJ...header.eyJ...payload.signature
-  examples:
-    FundsConfirmationConsentCreateRequest:
-      summary: Create a funds-confirmation consent
-      value:
-        Data:
-          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
-          DebtorAccount:
-            SchemeName: UK.OBIE.SortCodeAccountNumber
-            Identification: '30949301273801'
-            Name: Jane Smith
-            SecondaryIdentification: Roll 56988
-            Proxy:
-              Identification: '+441632960540'
-              Code: TELE
-              Type: Telephone
-    FundsConfirmationConsentCreateResponse:
-      summary: Funds-confirmation consent awaiting authorisation
-      value:
-        Data:
-          ConsentId: FCC-20260401-0001
-          CreationDateTime: '2026-04-01T10:15:30+00:00'
-          Status: AWAU
-          StatusUpdateDateTime: '2026-04-01T10:15:30+00:00'
-          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
-          DebtorAccount:
-            SchemeName: UK.OBIE.SortCodeAccountNumber
-            Identification: '30949301273801'
-            Name: Jane Smith
-            SecondaryIdentification: Roll 56988
-            Proxy:
-              Identification: '+441632960540'
-              Code: TELE
-              Type: Telephone
-        Links:
-          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmation-consents/FCC-20260401-0001
-        Meta: {}
-    FundsConfirmationConsentReadAuthorisedResponse:
-      summary: Authorised funds-confirmation consent
-      value:
-        Data:
-          ConsentId: FCC-20260401-0001
-          CreationDateTime: '2026-04-01T10:15:30+00:00'
-          Status: AUTH
-          StatusUpdateDateTime: '2026-04-01T10:20:30+00:00'
-          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
-          DebtorAccount:
-            SchemeName: UK.OBIE.SortCodeAccountNumber
-            Identification: '30949301273801'
-            Name: Jane Smith
-            SecondaryIdentification: Roll 56988
-            Proxy:
-              Identification: '+441632960540'
-              Code: TELE
-              Type: Telephone
-        Links:
-          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmation-consents/FCC-20260401-0001
-        Meta: {}
-    FundsConfirmationConsentReadMaskedPanResponse:
-      summary: Authorised funds-confirmation consent with masked PAN
-      description: ASPSPs may partially mask the account identification when returning PAN account details on GET.
-      value:
-        Data:
-          ConsentId: FCC-20260401-0002
-          CreationDateTime: '2026-04-01T10:15:30+00:00'
-          Status: AUTH
-          StatusUpdateDateTime: '2026-04-01T10:20:30+00:00'
-          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
-          DebtorAccount:
-            SchemeName: UK.OBIE.PAN
-            Identification: '4444********1111'
-            Name: Jane Smith
-            SecondaryIdentification: '008419'
-            Proxy:
-              Identification: '+441632960540'
-              Code: TELE
-              Type: Telephone
-        Links:
-          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmation-consents/FCC-20260401-0002
-        Meta: {}
-    FundsConfirmationCreateRequest:
-      summary: Create a funds-confirmation request
-      value:
-        Data:
-          ConsentId: FCC-20260401-0001
-          Reference: CARD-PURCHASE-001
-          InstructedAmount:
-            Amount: '20.00'
-            Currency: GBP
-    FundsConfirmationCreateResponse:
-      summary: Funds are available for the card purchase
-      value:
-        Data:
-          FundsConfirmationId: FC-20260401-0001
-          ConsentId: FCC-20260401-0001
-          CreationDateTime: '2026-04-01T10:25:30+00:00'
-          FundsAvailable: true
-          Reference: CARD-PURCHASE-001
-          InstructedAmount:
-            Amount: '20.00'
-            Currency: GBP
-        Links:
-          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmations/FC-20260401-0001
-        Meta: {}
-    FundsConfirmationUsdRequest:
-      summary: Create a funds-confirmation request for a USD account
-      description: Funds can be confirmed in USD only where the underlying payment account currency is USD.
-      value:
-        Data:
-          ConsentId: FCC-20260401-USD1
-          Reference: CARD-PURCHASE-USD
-          InstructedAmount:
-            Amount: '20.00'
-            Currency: USD
-    FundsConfirmationUsdResponse:
-      summary: Funds are available for the USD card purchase
-      description: Funds can be confirmed in USD only where the underlying payment account currency is USD.
-      value:
-        Data:
-          FundsConfirmationId: FC-20260401-USD1
-          ConsentId: FCC-20260401-USD1
-          CreationDateTime: '2026-04-01T10:25:30+00:00'
-          FundsAvailable: true
-          Reference: CARD-PURCHASE-USD
-          InstructedAmount:
-            Amount: '20.00'
-            Currency: USD
-        Links:
-          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmations/FC-20260401-USD1
-        Meta: {}
-    Error400InvalidField:
-      summary: Invalid field value
-      value:
-        Code: UK.OBIE.Field.Invalid
-        Message: One or more request fields are invalid.
-        Errors:
-          - ErrorCode: U002
-            Message: InstructedAmount.Currency must match the currency of the underlying payment account.
-            Path: Data.InstructedAmount.Currency
-            Url: https://docs.alphabank.com/open-banking/errors/U002
-    Error403InvalidConsentStatus:
-      summary: Consent is not authorised for funds confirmation
-      value:
-        Code: UK.OBIE.Resource.InvalidConsentStatus
-        Message: The consent is not in a status that allows funds confirmation.
-        Errors:
-          - ErrorCode: U009
-            Message: The funds-confirmation consent is not authorised for this request.
-            Path: Data.ConsentId
-            Url: https://docs.alphabank.com/open-banking/errors/U009
-    Error500Unexpected:
-      summary: Unexpected processing error
-      value:
-        Id: ERR-20260401-0001
-        Code: UK.OBIE.UnexpectedError
-        Message: An unexpected error occurred while processing the request.
-        Errors:
-          - ErrorCode: U000
-            Message: The ASPSP could not complete the request due to an unexpected processing error.
-            Url: https://docs.alphabank.com/open-banking/errors/U000
   responses:
     201FundsConfirmationConsentsCreated:
       description: Funds Confirmation Consent Created
@@ -504,15 +337,9 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
-          examples:
-            FundsConfirmationConsentCreateResponse:
-              $ref: '#/components/examples/FundsConfirmationConsentCreateResponse'
         application/json:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
-          examples:
-            FundsConfirmationConsentCreateResponse:
-              $ref: '#/components/examples/FundsConfirmationConsentCreateResponse'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
@@ -534,19 +361,9 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
-          examples:
-            FundsConfirmationConsentReadAuthorisedResponse:
-              $ref: '#/components/examples/FundsConfirmationConsentReadAuthorisedResponse'
-            FundsConfirmationConsentReadMaskedPanResponse:
-              $ref: '#/components/examples/FundsConfirmationConsentReadMaskedPanResponse'
         application/json:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
-          examples:
-            FundsConfirmationConsentReadAuthorisedResponse:
-              $ref: '#/components/examples/FundsConfirmationConsentReadAuthorisedResponse'
-            FundsConfirmationConsentReadMaskedPanResponse:
-              $ref: '#/components/examples/FundsConfirmationConsentReadMaskedPanResponse'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
@@ -582,19 +399,9 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationResponse1'
-          examples:
-            FundsConfirmationCreateResponse:
-              $ref: '#/components/examples/FundsConfirmationCreateResponse'
-            FundsConfirmationUsdResponse:
-              $ref: '#/components/examples/FundsConfirmationUsdResponse'
         application/json:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationResponse1'
-          examples:
-            FundsConfirmationCreateResponse:
-              $ref: '#/components/examples/FundsConfirmationCreateResponse'
-            FundsConfirmationUsdResponse:
-              $ref: '#/components/examples/FundsConfirmationUsdResponse'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationResponse1'
@@ -612,15 +419,9 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
-          examples:
-            Error400InvalidField:
-              $ref: '#/components/examples/Error400InvalidField'
         application/json:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
-          examples:
-            Error400InvalidField:
-              $ref: '#/components/examples/Error400InvalidField'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
@@ -648,15 +449,9 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
-          examples:
-            Error403InvalidConsentStatus:
-              $ref: '#/components/examples/Error403InvalidConsentStatus'
         application/json:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
-          examples:
-            Error403InvalidConsentStatus:
-              $ref: '#/components/examples/Error403InvalidConsentStatus'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
@@ -717,15 +512,9 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
-          examples:
-            Error500Unexpected:
-              $ref: '#/components/examples/Error500Unexpected'
         application/json:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
-          examples:
-            Error500Unexpected:
-              $ref: '#/components/examples/Error500Unexpected'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -44,6 +44,9 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/OBFundsConfirmationConsent1'
+            examples:
+              FundsConfirmationConsentCreateRequest:
+                $ref: '#/components/examples/FundsConfirmationConsentCreateRequest'
         description: Default
         required: true
       responses:
@@ -176,6 +179,11 @@ paths:
           application/json:
             schema:
               $ref: '#/components/schemas/OBFundsConfirmation1'
+            examples:
+              FundsConfirmationCreateRequest:
+                $ref: '#/components/examples/FundsConfirmationCreateRequest'
+              FundsConfirmationUsdRequest:
+                $ref: '#/components/examples/FundsConfirmationUsdRequest'
         description: Default
         required: true
       responses:
@@ -211,6 +219,7 @@ components:
       required: true
       schema:
         type: string
+        example: FCC-20260401-0001
     Authorization:
       in: header
       name: Authorization
@@ -218,6 +227,7 @@ components:
       description: An Authorisation Token as per <https://tools.ietf.org/html/rfc6750>
       schema:
         type: string
+        example: Bearer <access-token>
     x-customer-user-agent:
       in: header
       name: x-customer-user-agent
@@ -225,6 +235,7 @@ components:
       required: false
       schema:
         type: string
+        example: Mozilla/5.0 (Example PSU Device)
     x-fapi-customer-ip-address:
       in: header
       name: x-fapi-customer-ip-address
@@ -232,6 +243,7 @@ components:
       description: The PSU's IP address if the PSU is currently logged in with the TPP.
       schema:
         type: string
+        example: 203.0.113.42
     x-fapi-auth-date:
       in: header
       name: x-fapi-auth-date
@@ -245,6 +257,7 @@ components:
       schema:
         type: string
         pattern: '^(Mon|Tue|Wed|Thu|Fri|Sat|Sun), \d{2} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) \d{4} \d{2}:\d{2}:\d{2} (GMT|UTC)$'
+        example: Wed, 01 Apr 2026 10:15:30 GMT
     x-fapi-interaction-id:
       in: header
       name: x-fapi-interaction-id
@@ -252,6 +265,7 @@ components:
       description: An RFC4122 UID used as a correlation id.
       schema:
         type: string
+        example: 93bac548-d2de-4546-b106-880a5018460d
     x-jws-signature:
       in: header
       name: x-jws-signature
@@ -259,6 +273,7 @@ components:
       description: A detached JWS signature of the body of the payload.
       schema:
         type: string
+        example: eyJ...header.eyJ...payload.signature
     x-client-id:
       in: header
       name: x-client-id
@@ -271,6 +286,7 @@ components:
         This header __must not__ be used for client authentication
       schema:
         type: string
+        example: cbpii-client-12345
   headers:
     RateLimit-Policy:
       required: false
@@ -287,6 +303,7 @@ components:
         The **OPTIONAL** "w" parameter value conveys a time window.
       schema:
         type: string
+        example: '"default";q=100;w=10'
     RateLimit:
       required: false
       description: |-
@@ -302,11 +319,172 @@ components:
         The **OPTIONAL** "t" parameter value conveys the time window reset time for the identified policy.
       schema:
         type: string
+        example: '"default";r=50;t=30'
     x-jws-signature:
       required: false
       description: A detached JWS signature of the body of the payload.
       schema:
         type: string
+        example: eyJ...header.eyJ...payload.signature
+  examples:
+    FundsConfirmationConsentCreateRequest:
+      summary: Create a funds-confirmation consent
+      value:
+        Data:
+          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
+          DebtorAccount:
+            SchemeName: UK.OBIE.SortCodeAccountNumber
+            Identification: '30949301273801'
+            Name: Jane Smith
+            SecondaryIdentification: Roll 56988
+            Proxy:
+              Identification: '+441632960540'
+              Code: TELE
+              Type: Telephone
+    FundsConfirmationConsentCreateResponse:
+      summary: Funds-confirmation consent awaiting authorisation
+      value:
+        Data:
+          ConsentId: FCC-20260401-0001
+          CreationDateTime: '2026-04-01T10:15:30+00:00'
+          Status: AWAU
+          StatusUpdateDateTime: '2026-04-01T10:15:30+00:00'
+          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
+          DebtorAccount:
+            SchemeName: UK.OBIE.SortCodeAccountNumber
+            Identification: '30949301273801'
+            Name: Jane Smith
+            SecondaryIdentification: Roll 56988
+            Proxy:
+              Identification: '+441632960540'
+              Code: TELE
+              Type: Telephone
+        Links:
+          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmation-consents/FCC-20260401-0001
+        Meta: {}
+    FundsConfirmationConsentReadAuthorisedResponse:
+      summary: Authorised funds-confirmation consent
+      value:
+        Data:
+          ConsentId: FCC-20260401-0001
+          CreationDateTime: '2026-04-01T10:15:30+00:00'
+          Status: AUTH
+          StatusUpdateDateTime: '2026-04-01T10:20:30+00:00'
+          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
+          DebtorAccount:
+            SchemeName: UK.OBIE.SortCodeAccountNumber
+            Identification: '30949301273801'
+            Name: Jane Smith
+            SecondaryIdentification: Roll 56988
+            Proxy:
+              Identification: '+441632960540'
+              Code: TELE
+              Type: Telephone
+        Links:
+          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmation-consents/FCC-20260401-0001
+        Meta: {}
+    FundsConfirmationConsentReadMaskedPanResponse:
+      summary: Authorised funds-confirmation consent with masked PAN
+      description: ASPSPs may partially mask the account identification when returning PAN account details on GET.
+      value:
+        Data:
+          ConsentId: FCC-20260401-0002
+          CreationDateTime: '2026-04-01T10:15:30+00:00'
+          Status: AUTH
+          StatusUpdateDateTime: '2026-04-01T10:20:30+00:00'
+          ExpirationDateTime: '2026-10-01T10:15:30+00:00'
+          DebtorAccount:
+            SchemeName: UK.OBIE.PAN
+            Identification: '4444********1111'
+            Name: Jane Smith
+            SecondaryIdentification: '008419'
+            Proxy:
+              Identification: '+441632960540'
+              Code: TELE
+              Type: Telephone
+        Links:
+          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmation-consents/FCC-20260401-0002
+        Meta: {}
+    FundsConfirmationCreateRequest:
+      summary: Create a funds-confirmation request
+      value:
+        Data:
+          ConsentId: FCC-20260401-0001
+          Reference: CARD-PURCHASE-001
+          InstructedAmount:
+            Amount: '20.00'
+            Currency: GBP
+    FundsConfirmationCreateResponse:
+      summary: Funds are available for the card purchase
+      value:
+        Data:
+          FundsConfirmationId: FC-20260401-0001
+          ConsentId: FCC-20260401-0001
+          CreationDateTime: '2026-04-01T10:25:30+00:00'
+          FundsAvailable: true
+          Reference: CARD-PURCHASE-001
+          InstructedAmount:
+            Amount: '20.00'
+            Currency: GBP
+        Links:
+          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmations/FC-20260401-0001
+        Meta: {}
+    FundsConfirmationUsdRequest:
+      summary: Create a funds-confirmation request for a USD account
+      description: Funds can be confirmed in USD only where the underlying payment account currency is USD.
+      value:
+        Data:
+          ConsentId: FCC-20260401-USD1
+          Reference: CARD-PURCHASE-USD
+          InstructedAmount:
+            Amount: '20.00'
+            Currency: USD
+    FundsConfirmationUsdResponse:
+      summary: Funds are available for the USD card purchase
+      description: Funds can be confirmed in USD only where the underlying payment account currency is USD.
+      value:
+        Data:
+          FundsConfirmationId: FC-20260401-USD1
+          ConsentId: FCC-20260401-USD1
+          CreationDateTime: '2026-04-01T10:25:30+00:00'
+          FundsAvailable: true
+          Reference: CARD-PURCHASE-USD
+          InstructedAmount:
+            Amount: '20.00'
+            Currency: USD
+        Links:
+          Self: https://api.alphabank.com/open-banking/v4.0/cbpii/funds-confirmations/FC-20260401-USD1
+        Meta: {}
+    Error400InvalidField:
+      summary: Invalid field value
+      value:
+        Code: UK.OBIE.Field.Invalid
+        Message: One or more request fields are invalid.
+        Errors:
+          - ErrorCode: U002
+            Message: InstructedAmount.Currency must match the currency of the underlying payment account.
+            Path: Data.InstructedAmount.Currency
+            Url: https://docs.alphabank.com/open-banking/errors/U002
+    Error403InvalidConsentStatus:
+      summary: Consent is not authorised for funds confirmation
+      value:
+        Code: UK.OBIE.Resource.InvalidConsentStatus
+        Message: The consent is not in a status that allows funds confirmation.
+        Errors:
+          - ErrorCode: U009
+            Message: The funds-confirmation consent is not authorised for this request.
+            Path: Data.ConsentId
+            Url: https://docs.alphabank.com/open-banking/errors/U009
+    Error500Unexpected:
+      summary: Unexpected processing error
+      value:
+        Id: ERR-20260401-0001
+        Code: UK.OBIE.UnexpectedError
+        Message: An unexpected error occurred while processing the request.
+        Errors:
+          - ErrorCode: U000
+            Message: The ASPSP could not complete the request due to an unexpected processing error.
+            Url: https://docs.alphabank.com/open-banking/errors/U000
   responses:
     201FundsConfirmationConsentsCreated:
       description: Funds Confirmation Consent Created
@@ -326,9 +504,15 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
+          examples:
+            FundsConfirmationConsentCreateResponse:
+              $ref: '#/components/examples/FundsConfirmationConsentCreateResponse'
         application/json:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
+          examples:
+            FundsConfirmationConsentCreateResponse:
+              $ref: '#/components/examples/FundsConfirmationConsentCreateResponse'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
@@ -350,9 +534,19 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
+          examples:
+            FundsConfirmationConsentReadAuthorisedResponse:
+              $ref: '#/components/examples/FundsConfirmationConsentReadAuthorisedResponse'
+            FundsConfirmationConsentReadMaskedPanResponse:
+              $ref: '#/components/examples/FundsConfirmationConsentReadMaskedPanResponse'
         application/json:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
+          examples:
+            FundsConfirmationConsentReadAuthorisedResponse:
+              $ref: '#/components/examples/FundsConfirmationConsentReadAuthorisedResponse'
+            FundsConfirmationConsentReadMaskedPanResponse:
+              $ref: '#/components/examples/FundsConfirmationConsentReadMaskedPanResponse'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationConsentResponse1'
@@ -388,9 +582,19 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationResponse1'
+          examples:
+            FundsConfirmationCreateResponse:
+              $ref: '#/components/examples/FundsConfirmationCreateResponse'
+            FundsConfirmationUsdResponse:
+              $ref: '#/components/examples/FundsConfirmationUsdResponse'
         application/json:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationResponse1'
+          examples:
+            FundsConfirmationCreateResponse:
+              $ref: '#/components/examples/FundsConfirmationCreateResponse'
+            FundsConfirmationUsdResponse:
+              $ref: '#/components/examples/FundsConfirmationUsdResponse'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBFundsConfirmationResponse1'
@@ -408,9 +612,15 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
+          examples:
+            Error400InvalidField:
+              $ref: '#/components/examples/Error400InvalidField'
         application/json:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
+          examples:
+            Error400InvalidField:
+              $ref: '#/components/examples/Error400InvalidField'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
@@ -438,9 +648,15 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
+          examples:
+            Error403InvalidConsentStatus:
+              $ref: '#/components/examples/Error403InvalidConsentStatus'
         application/json:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
+          examples:
+            Error403InvalidConsentStatus:
+              $ref: '#/components/examples/Error403InvalidConsentStatus'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
@@ -501,9 +717,15 @@ components:
         application/json; charset=utf-8:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
+          examples:
+            Error500Unexpected:
+              $ref: '#/components/examples/Error500Unexpected'
         application/json:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
+          examples:
+            Error500Unexpected:
+              $ref: '#/components/examples/Error500Unexpected'
         application/jose+jwe:
           schema:
             $ref: '#/components/schemas/OBErrorResponse1'
@@ -548,6 +770,7 @@ components:
           type: string
           minLength: 1
           maxLength: 2048
+          example: '+441632960540'
         Code:
           $ref: '#/components/schemas/ExternalProxyAccountType1Code'
         Type:
@@ -555,6 +778,7 @@ components:
           description: Type of the proxy identification.
           minLength: 1
           maxLength: 35
+          example: Telephone
     ExternalProxyAccountType1Code:
       description: |-
         Specifies the external proxy account type code, as published in the proxy account type external code set.
@@ -583,6 +807,7 @@ components:
         - UBIL
         - VIPN
         - BIID
+      example: TELE
     ISODateTime:
       description: |-
         All dates in the JSON payloads are represented in ISO 8601 date-time format.
@@ -640,14 +865,17 @@ components:
           type: string
           minLength: 1
           maxLength: 500
+          example: InstructedAmount.Currency must match the currency of the underlying payment account.
         Path:
-          description: Recommended but optional reference to the JSON Path of the field with error, e.g., `Data.Initiation.InstructedAmount.Currency`
+          description: Recommended but optional reference to the JSON Path of the field with error, e.g., `Data.InstructedAmount.Currency`
           type: string
           minLength: 1
           maxLength: 500
+          example: Data.InstructedAmount.Currency
         Url:
           description: URL to help remediate the problem, or provide more information, or to API Reference, or help etc
           type: string
+          example: https://docs.alphabank.com/open-banking/errors/U002
       required:
         - ErrorCode
       additionalProperties: false
@@ -668,7 +896,7 @@ components:
             High level textual error code, to help categorise the errors.
           type: string
           minLength: 1
-          example: 400 BadRequest
+          example: UK.OBIE.Field.Invalid
           maxLength: 40
         Message:
           description: |-
@@ -677,7 +905,7 @@ components:
             Brief Error message
           type: string
           minLength: 1
-          example: There is something wrong with the request parameters provided
+          example: One or more request fields are invalid.
           maxLength: 500
         Errors:
           items:
@@ -704,11 +932,13 @@ components:
               type: string
               minLength: 1
               maxLength: 128
+              example: FCC-20260401-0001
             Reference:
               description: Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
               type: string
               minLength: 1
               maxLength: 35
+              example: CARD-PURCHASE-001
             InstructedAmount:
               type: object
               required:
@@ -720,10 +950,12 @@ components:
                   description: A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
                   type: string
                   pattern: '^\d{1,13}$|^\d{1,13}\.\d{1,5}$'
+                  example: '20.00'
                 Currency:
                   description: A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".
                   type: string
                   pattern: '^[A-Z]{3,3}$'
+                  example: GBP
       additionalProperties: false
     OBFundsConfirmationConsent1:
       type: object
@@ -746,6 +978,7 @@ components:
                 `2017-04-05T10:43:07+00:00`
               type: string
               format: date-time
+              example: '2026-10-01T10:15:30+00:00'
             DebtorAccount:
               type: object
               required:
@@ -766,11 +999,13 @@ components:
                     - UK.OBIE.Paym
                     - UK.OBIE.SortCodeAccountNumber
                     - UK.OBIE.Wallet
+                  example: UK.OBIE.SortCodeAccountNumber
                 Identification:
                   description: Identification assigned by an institution to identify an account. This identification is known by the account owner.
                   type: string
                   minLength: 1
                   maxLength: 256
+                  example: '30949301273801'
                 Name:
                   description: |-
                     Name of the account, as assigned by the account servicing institution.
@@ -779,6 +1014,7 @@ components:
                   type: string
                   minLength: 1
                   maxLength: 350
+                  example: Jane Smith
                 SecondaryIdentification:
                   description: |-
                     This is secondary identification of the account, as assigned by the account servicing institution.
@@ -787,6 +1023,7 @@ components:
                   type: string
                   minLength: 1
                   maxLength: 34
+                  example: Roll 56988
                 Proxy:
                   $ref: '#/components/schemas/OBProxy1'
       additionalProperties: false
@@ -809,6 +1046,7 @@ components:
               type: string
               minLength: 1
               maxLength: 128
+              example: FCC-20260401-0001
             CreationDateTime:
               description: |-
                 Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.
@@ -818,6 +1056,7 @@ components:
                 `2017-04-05T10:43:07+00:00`
               type: string
               format: date-time
+              example: '2026-04-01T10:15:30+00:00'
             Status:
               $ref: '#/components/schemas/OBInternalConsentStatus1Code'
             StatusReason:
@@ -833,6 +1072,7 @@ components:
                 `2017-04-05T10:43:07+00:00`
               type: string
               format: date-time
+              example: '2026-04-01T10:20:30+00:00'
             ExpirationDateTime:
               description: |-
                 Specified date and time the funds confirmation authorisation will expire.
@@ -844,6 +1084,7 @@ components:
                 `2017-04-05T10:43:07+00:00`
               type: string
               format: date-time
+              example: '2026-10-01T10:15:30+00:00'
             DebtorAccount:
               type: object
               required:
@@ -864,11 +1105,13 @@ components:
                     - UK.OBIE.Paym
                     - UK.OBIE.SortCodeAccountNumber
                     - UK.OBIE.Wallet
+                  example: UK.OBIE.SortCodeAccountNumber
                 Identification:
                   description: Identification assigned by an institution to identify an account. This identification is known by the account owner.
                   type: string
                   minLength: 1
                   maxLength: 256
+                  example: '30949301273801'
                 Name:
                   description: |-
                     Name of the account, as assigned by the account servicing institution.
@@ -877,6 +1120,7 @@ components:
                   type: string
                   minLength: 1
                   maxLength: 350
+                  example: Jane Smith
                 SecondaryIdentification:
                   description: |-
                     This is secondary identification of the account, as assigned by the account servicing institution.
@@ -885,6 +1129,7 @@ components:
                   type: string
                   minLength: 1
                   maxLength: 34
+                  example: Roll 56988
                 Proxy:
                   $ref: '#/components/schemas/OBProxy1'
         Links:
@@ -904,6 +1149,7 @@ components:
         - AUTH
         - CANC
         - EXPD
+      example: AUTH
     OBFundsConfirmationResponse1:
       type: object
       required:
@@ -924,11 +1170,13 @@ components:
               type: string
               minLength: 1
               maxLength: 40
+              example: FC-20260401-0001
             ConsentId:
               description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
               type: string
               minLength: 1
               maxLength: 128
+              example: FCC-20260401-0001
             CreationDateTime:
               description: |-
                 Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.
@@ -938,14 +1186,17 @@ components:
                 `2017-04-05T10:43:07+00:00`
               type: string
               format: date-time
+              example: '2026-04-01T10:25:30+00:00'
             FundsAvailable:
               description: Flag to indicate the result of a confirmation of funds check.
               type: boolean
+              example: true
             Reference:
               description: Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
               type: string
               minLength: 1
               maxLength: 35
+              example: CARD-PURCHASE-001
             InstructedAmount:
               type: object
               required:
@@ -957,10 +1208,12 @@ components:
                   description: A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
                   type: string
                   pattern: '^\d{1,13}$|^\d{1,13}\.\d{1,5}$'
+                  example: '20.00'
                 Currency:
                   description: A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".
                   type: string
                   pattern: '^[A-Z]{3,3}$'
+                  example: GBP
         Links:
           $ref: '#/components/schemas/Links'
         Meta:
@@ -974,7 +1227,7 @@ components:
       type: string
       minLength: 4
       maxLength: 4
-      example: U001
+      example: U002
     OBStatusReason:
       type: object
       properties:
@@ -986,14 +1239,16 @@ components:
             For a full list of values see `OBExternalStatusReason1Code` in *OB_Internal_CodeSet* [here](https://github.com/OpenBankingUK/External_Internal_CodeSets)
           minLength: 1
           maxLength: 4
-          example: ERIN
+          example: U009
         StatusReasonDescription:
           description: Description supporting the `StatusReasonCode`.
           type: string
           minLength: 1
           maxLength: 500
+          example: The consent is not in a status that allows funds confirmation.
         Path:
           type: string
           description: Optional reference to the JSON Path of the field when status reason refers to an object/field, e.g., `Data.DebtorAccount.SchemeName`
           minLength: 1
           maxLength: 500
+          example: Data.ConsentId


### PR DESCRIPTION
## Summary
- add reusable CBPII OpenAPI examples for consent and funds-confirmation request/response payloads
- add PAN and USD alternate examples, plus examples for existing CBPII error payload responses
- add key parameter and field-level examples and update the changelog

## Validation
- Parsed confirmation-funds-openapi.yaml and verified all components.examples references resolve

Note: JSON OpenAPI output is intentionally unchanged.