### PR TITLE
Refactor CBPII confirmation funds schemas

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -30,6 +30,15 @@ For v4.0.1 the following approach has been adopted for identifying changes:
 - Updated `x-jws-signature` to be optional in CBPII request/response modelling to align with the Open Banking spec pages/standard.
 - Updated CBPII enum descriptions to link directly to the relevant codeset CSV files.
 - Refactored CBPII `OBInternalAccountIdentification4Code` into a reusable schema reference.
+- Refactored CBPII Confirmation of Funds OpenAPI data dictionary schemas to use reusable component references aligned to the spec pages:
+  - `OBFundsConfirmationConsent1/Data` now references `OBFundsConfirmationConsentData1`
+  - `OBFundsConfirmationConsentResponse1/Data` now references `OBFundsConfirmationConsentDataResponse1`
+  - `OBFundsConfirmation1/Data` now references `OBFundsConfirmationData1`
+  - `OBFundsConfirmationResponse1/Data` now references `OBFundsConfirmationDataResponse1`
+  - `OBFundsConfirmationConsent1/Data/DebtorAccount` and `OBFundsConfirmationConsentResponse1/Data/DebtorAccount` now reference `OBCashAccountDebtorWithName`
+  - `OBFundsConfirmation1/Data/InstructedAmount` and `OBFundsConfirmationResponse1/Data/InstructedAmount` now reference `OBActiveOrHistoricCurrencyAndAmount`
+  - `OBFundsConfirmation1/Data/InstructedAmount/Amount` and `OBFundsConfirmationResponse1/Data/InstructedAmount/Amount` now reference `OBActiveCurrencyAndAmount_SimpleType`
+  - `OBFundsConfirmation1/Data/InstructedAmount/Currency` and `OBFundsConfirmationResponse1/Data/InstructedAmount/Currency` now reference `ActiveOrHistoricCurrencyCode`
 
 ### Removed
 

--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -555,6 +555,38 @@ components:
           description: Type of the proxy identification.
           minLength: 1
           maxLength: 35
+    OBCashAccountDebtorWithName:
+      type: object
+      required:
+        - SchemeName
+        - Identification
+      description: Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.
+      properties:
+        SchemeName:
+          $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
+        Identification:
+          description: Identification assigned by an institution to identify an account. This identification is known by the account owner.
+          type: string
+          minLength: 1
+          maxLength: 256
+        Name:
+          description: |-
+            Name of the account, as assigned by the account servicing institution.
+
+            Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
+          type: string
+          minLength: 1
+          maxLength: 350
+        SecondaryIdentification:
+          description: |-
+            This is secondary identification of the account, as assigned by the account servicing institution.
+
+            This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
+          type: string
+          minLength: 1
+          maxLength: 34
+        Proxy:
+          $ref: '#/components/schemas/OBProxy1'
     OBInternalAccountIdentification4Code:
       description: |-
         Name of the identification scheme, in a coded form as published in an external list.
@@ -605,6 +637,25 @@ components:
         `2017-04-05T10:43:07+00:00`
       type: string
       format: date-time
+    OBActiveOrHistoricCurrencyAndAmount:
+      type: object
+      required:
+        - Amount
+        - Currency
+      description: Amount of money to be confirmed as available funds in the debtor account. Contains an `Amount` and a `Currency`.
+      properties:
+        Amount:
+          $ref: '#/components/schemas/OBActiveCurrencyAndAmount_SimpleType'
+        Currency:
+          $ref: '#/components/schemas/ActiveOrHistoricCurrencyCode'
+    OBActiveCurrencyAndAmount_SimpleType:
+      description: A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
+      type: string
+      pattern: '^\d{1,13}$|^\d{1,13}\.\d{1,5}$'
+    ActiveOrHistoricCurrencyCode:
+      description: A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".
+      type: string
+      pattern: '^[A-Z]{3,3}$'
     Links:
       type: object
       description: Links relevant to the payload
@@ -706,183 +757,116 @@ components:
         - Data
       properties:
         Data:
-          type: object
-          required:
-            - ConsentId
-            - Reference
-            - InstructedAmount
-          properties:
-            ConsentId:
-              description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
-              type: string
-              minLength: 1
-              maxLength: 128
-            Reference:
-              description: Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
-              type: string
-              minLength: 1
-              maxLength: 35
-            InstructedAmount:
-              type: object
-              required:
-                - Amount
-                - Currency
-              description: Amount of money to be confirmed as available funds in the debtor account. Contains an `Amount` and a `Currency`.
-              properties:
-                Amount:
-                  description: A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-                  type: string
-                  pattern: '^\d{1,13}$|^\d{1,13}\.\d{1,5}$'
-                Currency:
-                  description: A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".
-                  type: string
-                  pattern: '^[A-Z]{3,3}$'
+          $ref: '#/components/schemas/OBFundsConfirmationData1'
       additionalProperties: false
+    OBFundsConfirmationData1:
+      type: object
+      required:
+        - ConsentId
+        - Reference
+        - InstructedAmount
+      properties:
+        ConsentId:
+          description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
+          type: string
+          minLength: 1
+          maxLength: 128
+        Reference:
+          description: Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
+          type: string
+          minLength: 1
+          maxLength: 35
+        InstructedAmount:
+          $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
     OBFundsConfirmationConsent1:
       type: object
       required:
         - Data
       properties:
         Data:
-          type: object
-          required:
-            - DebtorAccount
-          properties:
-            ExpirationDateTime:
-              description: |-
-                Specified date and time the funds confirmation authorisation will expire.
-
-                If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.
-
-                All date-time fields in responses must include the timezone. An example is below:
-
-                `2017-04-05T10:43:07+00:00`
-              type: string
-              format: date-time
-            DebtorAccount:
-              type: object
-              required:
-                - SchemeName
-                - Identification
-              description: Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.
-              properties:
-                SchemeName:
-                  $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
-                Identification:
-                  description: Identification assigned by an institution to identify an account. This identification is known by the account owner.
-                  type: string
-                  minLength: 1
-                  maxLength: 256
-                Name:
-                  description: |-
-                    Name of the account, as assigned by the account servicing institution.
-
-                    Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
-                  type: string
-                  minLength: 1
-                  maxLength: 350
-                SecondaryIdentification:
-                  description: |-
-                    This is secondary identification of the account, as assigned by the account servicing institution.
-
-                    This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-                  type: string
-                  minLength: 1
-                  maxLength: 34
-                Proxy:
-                  $ref: '#/components/schemas/OBProxy1'
+          $ref: '#/components/schemas/OBFundsConfirmationConsentData1'
       additionalProperties: false
+    OBFundsConfirmationConsentData1:
+      type: object
+      required:
+        - DebtorAccount
+      properties:
+        ExpirationDateTime:
+          description: |-
+            Specified date and time the funds confirmation authorisation will expire.
+
+            If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.
+
+            All date-time fields in responses must include the timezone. An example is below:
+
+            `2017-04-05T10:43:07+00:00`
+          type: string
+          format: date-time
+        DebtorAccount:
+          $ref: '#/components/schemas/OBCashAccountDebtorWithName'
     OBFundsConfirmationConsentResponse1:
       type: object
       required:
         - Data
       properties:
         Data:
-          type: object
-          required:
-            - ConsentId
-            - CreationDateTime
-            - Status
-            - StatusUpdateDateTime
-            - DebtorAccount
-          properties:
-            ConsentId:
-              description: Unique identification as assigned to identify the funds confirmation consent resource.
-              type: string
-              minLength: 1
-              maxLength: 128
-            CreationDateTime:
-              description: |-
-                Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.
-
-                All date-time fields in responses must include the timezone. An example is below:
-
-                `2017-04-05T10:43:07+00:00`
-              type: string
-              format: date-time
-            Status:
-              $ref: '#/components/schemas/OBInternalConsentStatus1Code'
-            StatusReason:
-              type: array
-              items:
-                $ref: '#/components/schemas/OBStatusReason'
-            StatusUpdateDateTime:
-              description: |-
-                Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.
-
-                All date-time fields in responses must include the timezone. An example is below:
-
-                `2017-04-05T10:43:07+00:00`
-              type: string
-              format: date-time
-            ExpirationDateTime:
-              description: |-
-                Specified date and time the funds confirmation authorisation will expire.
-
-                If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.
-
-                All date-time fields in responses must include the timezone. An example is below:
-
-                `2017-04-05T10:43:07+00:00`
-              type: string
-              format: date-time
-            DebtorAccount:
-              type: object
-              required:
-                - SchemeName
-                - Identification
-              description: Unambiguous identification of the account of the debtor to which a confirmation of funds consent will be applied.
-              properties:
-                SchemeName:
-                  $ref: '#/components/schemas/OBInternalAccountIdentification4Code'
-                Identification:
-                  description: Identification assigned by an institution to identify an account. This identification is known by the account owner.
-                  type: string
-                  minLength: 1
-                  maxLength: 256
-                Name:
-                  description: |-
-                    Name of the account, as assigned by the account servicing institution.
-
-                    Usage: The account name is the name or names of the account owner(s) represented at an account level. The account name is not the product name or the nickname of the account.
-                  type: string
-                  minLength: 1
-                  maxLength: 350
-                SecondaryIdentification:
-                  description: |-
-                    This is secondary identification of the account, as assigned by the account servicing institution.
-
-                    This can be used by building societies to additionally identify accounts with a roll number (in addition to a sort code and account number combination).
-                  type: string
-                  minLength: 1
-                  maxLength: 34
-                Proxy:
-                  $ref: '#/components/schemas/OBProxy1'
+          $ref: '#/components/schemas/OBFundsConfirmationConsentDataResponse1'
         Links:
           $ref: '#/components/schemas/Links'
         Meta:
           $ref: '#/components/schemas/Meta'
       additionalProperties: false
+    OBFundsConfirmationConsentDataResponse1:
+      type: object
+      required:
+        - ConsentId
+        - CreationDateTime
+        - Status
+        - StatusUpdateDateTime
+        - DebtorAccount
+      properties:
+        ConsentId:
+          description: Unique identification as assigned to identify the funds confirmation consent resource.
+          type: string
+          minLength: 1
+          maxLength: 128
+        CreationDateTime:
+          description: |-
+            Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.
+
+            All date-time fields in responses must include the timezone. An example is below:
+
+            `2017-04-05T10:43:07+00:00`
+          type: string
+          format: date-time
+        Status:
+          $ref: '#/components/schemas/OBInternalConsentStatus1Code'
+        StatusReason:
+          type: array
+          items:
+            $ref: '#/components/schemas/OBStatusReason'
+        StatusUpdateDateTime:
+          description: |-
+            Date and time at which the resource status was updated. All dates in the JSON payloads are represented in ISO 8601 date-time format.
+
+            All date-time fields in responses must include the timezone. An example is below:
+
+            `2017-04-05T10:43:07+00:00`
+          type: string
+          format: date-time
+        ExpirationDateTime:
+          description: |-
+            Specified date and time the funds confirmation authorisation will expire.
+
+            If this is not populated, the authorisation will be open ended. All dates in the JSON payloads are represented in ISO 8601 date-time format.
+
+            All date-time fields in responses must include the timezone. An example is below:
+
+            `2017-04-05T10:43:07+00:00`
+          type: string
+          format: date-time
+        DebtorAccount:
+          $ref: '#/components/schemas/OBCashAccountDebtorWithName'
     OBInternalConsentStatus1Code:
       description: |-
         Specifies the status of consent resource in code form.
@@ -901,62 +885,51 @@ components:
         - Data
       properties:
         Data:
-          type: object
-          required:
-            - FundsConfirmationId
-            - ConsentId
-            - CreationDateTime
-            - FundsAvailable
-            - Reference
-            - InstructedAmount
-          properties:
-            FundsConfirmationId:
-              description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource.
-              type: string
-              minLength: 1
-              maxLength: 40
-            ConsentId:
-              description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
-              type: string
-              minLength: 1
-              maxLength: 128
-            CreationDateTime:
-              description: |-
-                Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.
-
-                All date-time fields in responses must include the timezone. An example is below:
-
-                `2017-04-05T10:43:07+00:00`
-              type: string
-              format: date-time
-            FundsAvailable:
-              description: Flag to indicate the result of a confirmation of funds check.
-              type: boolean
-            Reference:
-              description: Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
-              type: string
-              minLength: 1
-              maxLength: 35
-            InstructedAmount:
-              type: object
-              required:
-                - Amount
-                - Currency
-              description: Amount of money to be confirmed as available funds in the debtor account. Contains an `Amount` and a `Currency`.
-              properties:
-                Amount:
-                  description: A number of monetary units specified in an active currency where the unit of currency is explicit and compliant with ISO 4217.
-                  type: string
-                  pattern: '^\d{1,13}$|^\d{1,13}\.\d{1,5}$'
-                Currency:
-                  description: A code allocated to a currency by a Maintenance Agency under an international identification scheme, as described in the latest edition of the international standard ISO 4217 "Codes for the representation of currencies and funds".
-                  type: string
-                  pattern: '^[A-Z]{3,3}$'
+          $ref: '#/components/schemas/OBFundsConfirmationDataResponse1'
         Links:
           $ref: '#/components/schemas/Links'
         Meta:
           $ref: '#/components/schemas/Meta'
       additionalProperties: false
+    OBFundsConfirmationDataResponse1:
+      type: object
+      required:
+        - FundsConfirmationId
+        - ConsentId
+        - CreationDateTime
+        - FundsAvailable
+        - Reference
+        - InstructedAmount
+      properties:
+        FundsConfirmationId:
+          description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation resource.
+          type: string
+          minLength: 1
+          maxLength: 40
+        ConsentId:
+          description: Unique identification as assigned by the ASPSP to uniquely identify the funds confirmation consent resource.
+          type: string
+          minLength: 1
+          maxLength: 128
+        CreationDateTime:
+          description: |-
+            Date and time at which the resource was created. All dates in the JSON payloads are represented in ISO 8601 date-time format.
+
+            All date-time fields in responses must include the timezone. An example is below:
+
+            `2017-04-05T10:43:07+00:00`
+          type: string
+          format: date-time
+        FundsAvailable:
+          description: Flag to indicate the result of a confirmation of funds check.
+          type: boolean
+        Reference:
+          description: Unique reference, as assigned by the CBPII, to unambiguously refer to the request related to the payment transaction.
+          type: string
+          minLength: 1
+          maxLength: 35
+        InstructedAmount:
+          $ref: '#/components/schemas/OBActiveOrHistoricCurrencyAndAmount'
     OBExternalStatusReason1Code:
       description: |-
         Low level textual error code.


### PR DESCRIPTION
CBPII Confirmation of Funds currently defines several data dictionary objects inline in the OpenAPI YAML, which makes the schema names diverge from the published spec pages and harder to reuse consistently.

This refactors the YAML-only Confirmation of Funds schemas so the listed data dictionary paths reference named reusable components: the four top-level `Data` payload objects, `OBCashAccountDebtorWithName`, `OBActiveOrHistoricCurrencyAndAmount`, `OBActiveCurrencyAndAmount_SimpleType`, and `ActiveOrHistoricCurrencyCode`. The changelog now records each affected path and the component it resolves to.

No JSON OpenAPI output was changed.