### PR TITLE
Clarify CBPII security scheme descriptions

### DIFF
--- a/dist/openapi/confirmation-funds-openapi.yaml
+++ b/dist/openapi/confirmation-funds-openapi.yaml
@@ -522,11 +522,11 @@ components:
     TPPOAuth2Security:
       type: oauth2
       description: |-
-        TPP client credential authorisation flow with the ASPSP.
+        TPP client credentials authorisation flow with the ASPSP.
 
         FAPI 1 Advanced / OAuth 2.0 client credentials authorisation flow with the ASPSP. Access tokens are sent on resource requests using the standard HTTP Authorization header with the Bearer authentication scheme: `Authorization: Bearer <access-token>`.
 
-        This OpenAPI security scheme represents the OAuth2 access-token requirement. Additional Open Banking/FAPI requirements such as transport security, client authentication method, signing, PAR/JAR, or certificate binding are profiled by the Open Banking security profile and may not be fully expressible in OpenAPI 3.0 securitySchemes.
+        This OpenAPI security scheme represents the OAuth2 access-token requirement. Additional Open Banking/FAPI requirements such as transport security, client authentication method, PAR/JAR, or certificate binding are profiled by the Open Banking security profile and may not be fully expressible in OpenAPI 3.0 securitySchemes.
       flows:
         clientCredentials:
           tokenUrl: https://authserver.example/token
@@ -535,11 +535,11 @@ components:
     PSUOAuth2Security:
       type: oauth2
       description: |-
-        OAuth flow, it is required when the PSU needs to perform SCA with the ASPSP when a TPP wants to access an ASPSP resource owned by the PSU
+        OAuth flow, it is required when the PSU needs to perform SCA with the ASPSP when a TPP wants to access an ASPSP resource owned by the PSU.
 
-        FAPI 1 Advanced / OAuth 2.0 authorisation code flow with the ASPSP. Access tokens are sent on resource requests using the standard HTTP Authorization header with the Bearer scheme: `Authorization: Bearer <access_token>`
+        FAPI 1 Advanced / OAuth 2.0 authorisation code flow with the ASPSP. Access tokens are sent on resource requests using the standard HTTP Authorization header with the Bearer scheme: `Authorization: Bearer <access-token>`.
 
-        This OpenAPI security scheme represents the OAuth2 access-token requirement. Additional Open Banking/FAPI requirements such as transport security, client authentication method, signing, PAR/JAR, or certificate binding are profiled by the Open Banking security profile and may not be fully expressible in OpenAPI 3.0 securitySchemes.
+        This OpenAPI security scheme represents the OAuth2 access-token requirement. Additional Open Banking/FAPI requirements such as transport security, client authentication method, PAR/JAR, or certificate binding are profiled by the Open Banking security profile and may not be fully expressible in OpenAPI 3.0 securitySchemes.
       flows:
         authorizationCode:
           authorizationUrl: https://authserver.example/authorization


### PR DESCRIPTION
This keeps the CBPII OpenAPI security scheme prose focused on OAuth token requirements while improving wording consistency.

The change updates the client credentials wording, normalizes the authorization code flow description, and removes signing from the generic additional FAPI requirements list in the security scheme descriptions.

Validation: parsed `dist/openapi/confirmation-funds-openapi.yaml` successfully.